### PR TITLE
Add compound monitor type, add ping_ttl option, send mime email instead of plain text

### DIFF
--- a/Alerters/mail.py
+++ b/Alerters/mail.py
@@ -44,8 +44,7 @@ class EMailAlerter(Alerter):
         type = self.should_alert(monitor)
         (days, hours, minutes, seconds) = self.get_downtime(monitor)
 
-        #host = "on host %s" % self.hostname
-        host = ""
+        host = "on host %s" % self.hostname
         if monitor.is_remote():
             host = " on %s " % monitor.running_on
 
@@ -58,7 +57,8 @@ class EMailAlerter(Alerter):
         elif type == "failure":
             message['Subject'] = "[%s] Monitor %s Failed!" % ( self.hostname, name)
             body = """Monitor %s%s has failed.
-            Failed at: %s\nDowntime: %d+%02d:%02d:%02d
+            Failed at: %s
+            Downtime: %d+%02d:%02d:%02d
             Virtual failure count: %d
             Additional info: %s
             Description: %s""" % (
@@ -76,7 +76,7 @@ class EMailAlerter(Alerter):
                 body += "\nNo recovery info available"
 
         elif type == "success":
-            message['Subject'] = "[%s] Monitor %s succeeded" % (self.from_addr, self.to_addr, self.hostname, name)
+            message['Subject'] = "[%s] Monitor %s succeeded" % (self.hostname, name)
             body = "Monitor %s%s is back up.\nOriginally failed at: %s\nDowntime: %d+%02d:%02d:%02d\nDescription: %s" % (name, host, self.format_datetime(monitor.first_failure_time()), days, hours, minutes, seconds, monitor.describe())
 
         elif type == "catchup":
@@ -99,5 +99,4 @@ class EMailAlerter(Alerter):
                 self.available = False
         else:
             print "dry_run: would send email: %s" % message.as_string()
-
 

--- a/Alerters/mail.py
+++ b/Alerters/mail.py
@@ -1,4 +1,6 @@
 import smtplib
+from email.MIMEMultipart import MIMEMultipart
+from email.MIMEText import MIMEText
 
 from alerter import Alerter
 
@@ -46,53 +48,56 @@ class EMailAlerter(Alerter):
         host = ""
         if monitor.is_remote():
             host = " on %s " % monitor.running_on
-        
+
+        message = MIMEMultipart()
+        message['From'] = self.from_addr
+        message['To'] = self.to_addr
+
         if type == "":
             return
         elif type == "failure":
-            message = "From: %s\r\nTo: %s\r\nSubject: [%s] Monitor %s failed!" % (self.from_addr, self.to_addr, self.hostname, name)
-            message = message + "\r\n\r\n"
+            message['Subject'] = "[%s] Monitor %s Failed!" % ( self.hostname, name)
+            body = """Monitor %s%s has failed.
+            Failed at: %s\nDowntime: %d+%02d:%02d:%02d
+            Virtual failure count: %d
+            Additional info: %s
+            Description: %s""" % (
+                    name,
+                    host,
+                    self.format_datetime(monitor.first_failure_time()),
+                    days, hours, minutes, seconds,
+                    monitor.virtual_fail_count(),
+                    monitor.get_result(),
+                    monitor.describe())
             try:
-                message = message + """Monitor %s%s has failed.
-                Failed at: %s\nDowntime: %d+%02d:%02d:%02d
-                Virtual failure count: %d                
-                Additional info: %s
-                Description: %s""" % (
-                        name, 
-                        host, 
-                        self.format_datetime(monitor.first_failure_time()), 
-                        days, hours, minutes, seconds, 
-                        monitor.virtual_fail_count(), 
-                        monitor.get_result(), 
-                        monitor.describe())
                 if monitor.recover_info != "":
-                    message += "\nRecovery info: %s" % monitor.recover_info
-            except:
-                message = message + "(unable to generate message!)"
+                    body += "\nRecovery info: %s" % monitor.recover_info
+            except AttributeError:
+                body += "\nNo recovery info available"
 
         elif type == "success":
-            message = "From: %s\r\nTo: %s\r\nSubject: [%s] Monitor %s succeeded" % (self.from_addr, self.to_addr, self.hostname, name)
-            message = message + "\r\n\r\n"
-            message = message + "Monitor %s%s is back up.\nOriginally failed at: %s\nDowntime: %d+%02d:%02d:%02d\nDescription: %s" % (name, host, self.format_datetime(monitor.first_failure_time()), days, hours, minutes, seconds, monitor.describe())
+            message['Subject'] = "[%s] Monitor %s succeeded" % (self.from_addr, self.to_addr, self.hostname, name)
+            body = "Monitor %s%s is back up.\nOriginally failed at: %s\nDowntime: %d+%02d:%02d:%02d\nDescription: %s" % (name, host, self.format_datetime(monitor.first_failure_time()), days, hours, minutes, seconds, monitor.describe())
 
         elif type == "catchup":
-            message = "From: %s\r\nTo: %s\r\nSubject: [%s] Monitor %s failed earlier!" % (self.from_addr, self.to_addr, self.hostname, name)
-            message = message + "\r\n\r\n"
-            message = message + "Monitor %s%s failed earlier while this alerter was out of hours.\nFailed at: %s\nVirtual failure count: %d\nAdditional info: %s\nDescription: %s" % (name, host, self.format_datetime(monitor.first_failure_time()), monitor.virtual_fail_count(), monitor.get_result(), monitor.describe())
+            message['Subject'] = "[%s] Monitor %s failed earlier!" % (self.from_addr, self.to_addr, self.hostname, name)
+            body = "Monitor %s%s failed earlier while this alerter was out of hours.\nFailed at: %s\nVirtual failure count: %d\nAdditional info: %s\nDescription: %s" % (name, host, self.format_datetime(monitor.first_failure_time()), monitor.virtual_fail_count(), monitor.get_result(), monitor.describe())
 
         else:
             print "Unknown alert type %s" % type
             return
 
+        message.attach(MIMEText(body,'plain'))
+
         if not self.dry_run:
             try:
                 server = smtplib.SMTP(self.mail_host)
-                server.sendmail(self.from_addr, self.to_addr, message)
+                server.sendmail(self.from_addr, self.to_addr, message.as_string())
                 server.quit()
             except Exception, e:
                 print "Couldn't send mail: %s", e
                 self.available = False
         else:
-            print "dry_run: would send email: %s" % message
+            print "dry_run: would send email: %s" % message.as_string()
 
 

--- a/Monitors/compound.py
+++ b/Monitors/compound.py
@@ -1,0 +1,71 @@
+
+"""compound checks (logical and of failure of multiple probes) for SimpleMonitor."""
+
+import urllib
+import urllib2
+import re
+import os
+import socket
+import datetime
+
+from monitor import Monitor
+
+
+class CompoundMonitor(Monitor):
+    """Combine (logical-and) multiple failures for emergency escalation.
+
+    Check most recent proble of provided monitors, if all are fail, then report fail.
+    """
+
+    type = "compound"
+
+    def __init__(self, name, config_options):
+        Monitor.__init__(self, name, config_options)
+        monitors=[]
+        try:
+            monitors = [ele.strip() for ele in config_options["monitors"].split(",")]
+        except:
+            raise RuntimeError("Required configuration fields missing")
+        min_fail = len(monitors)
+        try:
+            min_fail = config_options["min_fail"]
+        except:
+            pass
+        self.min_fail = min_fail
+        self.monitors = monitors
+        self.m = -1
+        self.mt = None
+
+    def run_test(self):
+        # we depend on the other tests to run, just check them
+        failcount = self.min_fail
+        for i in self.monitors:
+            if self.m[i].get_success_count() > 0 and self.m[i].tests_run > 0:
+                failcount -=1
+        return (failcount > 0)
+
+    def describe(self):
+        """Explains what we do."""
+        message = "Checking that %s tests both failed" % (self.url)
+        return message
+
+    def get_params(self):
+        return (self.monitors)
+
+    def set_mon_refs(self, mmm):
+        """ stash a ref to the global monitor list so we can examine later """
+        self.mt = mmm
+
+    def post_config_setup(self):
+        """ make a nice little dict of just the monitors we need """
+        if self.m != -1:
+            return
+        self.m = {}
+        for i in self.mt.monitors.keys():
+            if i in self.monitors:
+                self.m[i] = self.mt.monitors[i]
+        #make sure we find all of our monitors or die during config
+        for i in self.monitors:
+            if i not in self.m.keys():
+                raise RuntimeError("No such monitor %s in compound monitor" % i)
+

--- a/Monitors/monitor.py
+++ b/Monitors/monitor.py
@@ -47,7 +47,7 @@ class Monitor:
 
     failures = 0
     last_failure = None
-    
+
     # this is the time we last received data into this monitor (if we're remote)
     last_update = None
 
@@ -81,7 +81,7 @@ class Monitor:
             self.set_recover_command(config_options["recover_command"])
         self.running_on = self.short_hostname()
         self.name = name
-    
+
     def set_recover_command(self, command):
         self.recover_command = command
 
@@ -126,7 +126,7 @@ class Monitor:
             return False
         else:
             return True
-        
+
     def first_failure(self):
         """Check if this is our first failure (past tolerance)."""
         if self.error_count == (self.tolerance + 1):
@@ -149,7 +149,7 @@ class Monitor:
         """Reset the monitor's dependency list back to default."""
         self.deps = copy.copy(self._dependencies)
 
-    def dependency_succeeded(self, dependency): 
+    def dependency_succeeded(self, dependency):
         """Remove a dependency from the current version of the list."""
         try:
             self.deps.remove(dependency)
@@ -167,7 +167,7 @@ class Monitor:
 
     def log_result(self, name, logger):
         """Save our latest result to the logger.
-        
+
         To be removed."""
         if self.error_count > self.tolerance:
             result = 0
@@ -183,7 +183,7 @@ class Monitor:
         """Send an alert when we first fail.
 
         Set first_only to False to generate mail every time.
-        
+
         To be removed."""
 
         if self.virtual_fail_count() == 1:
@@ -252,7 +252,7 @@ class Monitor:
 
     def record_skip(self, which_dep):
         """Record that we were skipped.
-        
+
         We pretend to have succeeded as we don't want notifications sent."""
         self.record_success()
         self.was_skipped = True
@@ -306,7 +306,7 @@ class Monitor:
 
     def should_run(self):
         """Check if we should run our tests.
-        
+
         We always run if the minimum gap is 0, or if we're currently failing.
         Otherwise, we run if the last time we ran was more than minimum_gap seconds ago.
         """
@@ -342,6 +342,10 @@ class Monitor:
             self.recover_info = "Unable to run command: %s" % e
 
         return
+
+    def post_config_setup(self):
+        """ any post config setup needed """
+        pass
 
 
 class MonitorFail(Monitor):

--- a/Monitors/network.py
+++ b/Monitors/network.py
@@ -13,7 +13,7 @@ from monitor import Monitor
 
 class MonitorHTTP(Monitor):
     """Check an HTTP server is working right.
-    
+
     We can either check that we get a 200 OK back, or we can check for a regexp match in the page.
     """
 
@@ -30,7 +30,7 @@ class MonitorHTTP(Monitor):
             url = config_options["url"]
         except:
             raise RuntimeError("Required configuration fields missing")
-        
+
         if config_options.has_key("regexp"):
             regexp = config_options["regexp"]
         else:
@@ -172,7 +172,11 @@ class MonitorHost(Monitor):
             self.ping_regexp = "Reply from "
             self.time_regexp = "Average = (?P<ms>\d+)ms"
         else:
-            self.ping_command = "ping -c1 -t5 %s 2> /dev/null"
+            try:
+                ping_ttl = config_options["ping_ttl"]
+            except:
+                ping_ttl = "5"
+            self.ping_command = "ping -c1 -t"+ ping_ttl + " %s 2> /dev/null"
             self.ping_regexp = "bytes from"
             #XXX this regexp is only for freebsd at the moment; not sure about other platforms
             #XXX looks like Linux uses this format too

--- a/Monitors/network.py
+++ b/Monitors/network.py
@@ -91,7 +91,9 @@ class MonitorHTTP(Monitor):
             socket.setdefaulttimeout(original_timeout)
             return False
         except Exception, e:
-            self.record_fail("Exception while trying to open url: %s" % e)
+            #import traceback
+            #traceback.print_exc()
+            self.record_fail("Exception while trying to open url: %s" % (e))
             socket.setdefaulttimeout(original_timeout)
             return False
 


### PR DESCRIPTION
So there are 3 basic changes here.  

I add a "compound monitor" type which you can specify other monitors - it fails when multiple of them fail (configurable number of them)

to the network ping test I added a configurable option for max ttl (was hard coded at 5...)

Some mail providers (in particular t-mobile's email to txt-msg servers) mail servers are confused 
by simple plain text messages that simplemonitor produces.  Making the body of the message be 
a MIME blob solves the problem and opens the door for more complicated notification emails.

I could split these three... I also dont know if you are even using or maintaining this code any more...