### PR TITLE
Add Command monitor type

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -151,8 +151,12 @@ def load_monitors(m, filename, quiet):
         elif type == "compound":
             new_monitor = Monitors.compound.CompoundMonitor(monitor, config_options)
             new_monitor.set_mon_refs(m)
+
         elif type == 'dns':
             new_monitor = Monitors.network.MonitorDNS(monitor, config_options)
+
+        elif type == 'command':
+            new_monitor = Monitors.host.MonitorCommand(monitor, config_options)
 
         else:
             sys.stderr.write("Unknown type %s for monitor %s\n" % (type, monitor))


### PR DESCRIPTION
@tlegras - this look like what you had in mind?

I had to make it split the `command` option by space, as you're supposed to pass the command and it's arguments as a sequence (or use `shell=True` and I'm not going anywhere near that :) )

Otherwise this is your code with a couple of minor tweaks, thanks very much!