### PR TITLE
Add a sample upstart script

### DIFF
--- a/scripts/init/simplemonitor.conf
+++ b/scripts/init/simplemonitor.conf
@@ -1,0 +1,18 @@
+# Simplemonitor upstart script
+# Assumes existence of 'simplemonitor' user/group
+
+description "simplemonitor startup script"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+console log
+
+respawn
+setuid simplemonitor
+setgid simplemonitor
+
+script
+  cd /opt/simplemonitor
+  exec python /opt/simplemonitor/monitor.py
+end script


### PR DESCRIPTION
For Debian/Ubuntu systems. Will launch monitor on startup and respawn if it dies.