### PR TITLE
Logging improvements

### DIFF
--- a/Loggers/file.py
+++ b/Loggers/file.py
@@ -57,15 +57,20 @@ class FileLogger(Logger):
             datestring = self.format_datetime(datetime.datetime.now())
         try:
             if monitor.virtual_fail_count() > 0:
-                self.file_handle.write("%s %s: failed since %s; VFC=%d (%s)" % (
+                self.file_handle.write("%s %s: failed since %s; VFC=%d (%s) (%0.3fs)" % (
                     datestring,
                     name,
                     self.format_datetime(monitor.first_failure_time()),
                     monitor.virtual_fail_count(),
-                    monitor.get_result()
+                    monitor.get_result(),
+                    monitor.last_run_duration
                 ))
             else:
-                self.file_handle.write("%s %s: ok" % (datestring, name))
+                self.file_handle.write("%s %s: ok (%0.3fs)" % (
+                    datestring,
+                    name,
+                    monitor.last_run_duration
+                ))
             self.file_handle.write("\n")
 
             if not self.buffered:

--- a/Loggers/file.py
+++ b/Loggers/file.py
@@ -19,6 +19,7 @@ class FileLogger(Logger):
     filename = ""
     only_failures = False
     buffered = True
+    dateformat = None
 
     def __init__(self, config_options={}):
         Logger.__init__(self, config_options)
@@ -39,15 +40,32 @@ class FileLogger(Logger):
             if config_options["buffered"] == "0":
                 self.buffered = False
 
+        if "dateformat" in config_options:
+            self.dateformat = config_options['dateformat']
+
     def save_result2(self, name, monitor):
         if self.only_failures and monitor.virtual_fail_count() == 0:
             return
 
+        dateformat = 'timestamp'
+        if self.dateformat == 'iso8601':
+            dateformat = 'iso8601'
+
+        if dateformat == 'timestamp':
+            datestring = str(int(time.time()))
+        elif dateformat == 'iso8601':
+            datestring = self.format_datetime(datetime.datetime.now())
         try:
             if monitor.virtual_fail_count() > 0:
-                self.file_handle.write("%d %s: failed since %s; VFC=%d (%s)" % (int(time.time()), name, monitor.first_failure_time().isoformat(), monitor.virtual_fail_count(), monitor.get_result()))
+                self.file_handle.write("%s %s: failed since %s; VFC=%d (%s)" % (
+                    datestring,
+                    name,
+                    self.format_datetime(monitor.first_failure_time()),
+                    monitor.virtual_fail_count(),
+                    monitor.get_result()
+                ))
             else:
-                self.file_handle.write("%d %s: ok" % (int(time.time()), name))
+                self.file_handle.write("%s %s: ok" % (datestring, name))
             self.file_handle.write("\n")
 
             if not self.buffered:

--- a/Loggers/logger.py
+++ b/Loggers/logger.py
@@ -80,5 +80,8 @@ class Logger:
         if dt is None:
             return ""
 
-        dt = dt.replace(microsecond=0)
-        return dt.isoformat(" ")
+        if isinstance(dt, datetime.datetime):
+            dt = dt.replace(microsecond=0)
+            return dt.isoformat(' ')
+        else:
+            return dt

--- a/Monitors/monitor.py
+++ b/Monitors/monitor.py
@@ -36,6 +36,7 @@ class Monitor:
     success_count = 0
     tests_run = 0
     last_error_count = 0
+    last_run_duration = 0
 
     minimum_gap = 0
     last_run = 0

--- a/simplemonitor.py
+++ b/simplemonitor.py
@@ -3,8 +3,7 @@ import signal
 import copy
 import pickle
 import datetime
-
-import Monitors.monitor
+import time
 
 
 class SimpleMonitor:
@@ -113,7 +112,10 @@ class SimpleMonitor:
                 try:
                     if self.monitors[monitor].should_run():
                         not_run = False
+                        start_time = time.time()
                         self.monitors[monitor].run_test()
+                        end_time = time.time()
+                        self.monitors[monitor].last_run_duration = end_time - start_time
                     else:
                         not_run = True
                         if verbose:


### PR DESCRIPTION
Add an option for ISO 8601 timestamps at start of log file lines.
Track time taken for monitor to run tests, and include (only for now) in log file output.

@hattesen, these work for you? :)