### PR TITLE
Fix double-call to record_fail in MonitorHost run_test

### DIFF
--- a/Monitors/network.py
+++ b/Monitors/network.py
@@ -267,7 +267,7 @@ class MonitorHost(Monitor):
                         pingtime = matches.group("ms")
         except Exception, e:
             self.record_fail(e)
-            pass
+            return False
         if success:
             if pingtime > 0:
                 self.record_success("%sms" % pingtime)


### PR DESCRIPTION
When Exception e gets raised self.record_fail() is called two times: inside the exception
handler and then at the end of the function, causing the virtual fail count to increment by 2
instead of just 1.
Replace the pass statement with a return False to fix this bug.