### PR TITLE
add parallelization of the monitor checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tags
 monitor.ini
 monitors.ini
 monitor.json
+monitor.html

--- a/Alerters/mail.py
+++ b/Alerters/mail.py
@@ -110,9 +110,9 @@ class EMailAlerter(Alerter):
         if not self.dry_run:
             try:
                 if self.ssl is None or self.ssl == 'starttls':
-                    server = smtplib.SMTP(self.mail_host, self.mail_port)
+                    server = smtplib.SMTP(self.mail_host, self.mail_port, timeout=5.0)
                 elif self.ssl == 'yes':
-                    server = smtplib.SMTP_SSL(self.mail_host, self.mail_port)
+                    server = smtplib.SMTP_SSL(self.mail_host, self.mail_port, timeout=5.0)
 
                 if self.ssl == 'starttls':
                     server.starttls()

--- a/monitor.py
+++ b/monitor.py
@@ -364,6 +364,16 @@ def main():
     except:
         key = None
 
+    try:
+        # get the maximum of thread workers.
+        max_workers = config.get("monitor", "max_workers")
+        max_workers = int(max_workers)
+    except:
+        # if unspecified, the thread pool executor creates (cpu_count * 5) workers.
+        max_workers = None
+
+    m.set_max_workers(max_workers)
+
     if enable_remote:
         if not options.quiet:
             print "--> Starting remote listener thread"

--- a/simplemonitor.py
+++ b/simplemonitor.py
@@ -6,6 +6,7 @@ import datetime
 import time
 
 from concurrent.futures import ThreadPoolExecutor
+import concurrent.futures
 
 
 class SimpleMonitor:
@@ -89,6 +90,7 @@ class SimpleMonitor:
 
         not_run = False
 
+        fs = []
         while len(joblist) > 0:
             with ThreadPoolExecutor(self.max_workers) as executor:
                 new_joblist = []
@@ -119,11 +121,12 @@ class SimpleMonitor:
                                         print "new_joblist is currently", new_joblist
                                 break
                         continue
-
-                    executor.submit(self.run_in_thread, failed, joblist, monitor, not_run, verbose)
+                    fs.append(executor.submit(self.run_in_thread, failed, joblist, monitor, not_run, verbose))
+                concurrent.futures.wait(fs)
+                fs = []
             joblist = copy.copy(new_joblist)
             if verbose:
-                print
+                print("")
 
     def run_in_thread(self, failed, joblist, monitor, not_run, verbose):
         try:


### PR DESCRIPTION
when doing many checks in serial it can take minutes until all checks are done. with this approach a single run takes at most the one with the longest check. By default, `cpu_count * 5` workers are created. If in the `monitors` section `max_workers=1` is specified, they behave essentially the same as before.

although, if verbosity is enabled, some printed sentences may end up in the same line. That may happen in amateur multi-threading ;)