### PR TITLE
Add username config for Slack; Allow channel to be None

### DIFF
--- a/Alerters/slack.py
+++ b/Alerters/slack.py
@@ -29,25 +29,28 @@ class SlackAlerter(Alerter):
         else:
             channel = None
 
+        if 'username' in config_options:
+            username = config_options['username']
+        else:
+            username = None
+
         if url == "":
             raise RuntimeError("missing url")
 
         self.url = url
         self.channel = channel
+        self.username = username
 
     def send_alert(self, name, monitor):
         """Send the message."""
-
-        if self.channel is None:
-            return
 
         type = self.should_alert(monitor)
         (days, hours, minutes, seconds) = self.get_downtime(monitor)
 
         host = "on host %s" % self.hostname
 
-        if self.channel is not None:
-            message_json = {'channel': self.channel}
+        if self.username is not None:
+            message_json = {'username': self.username}
         else:
             message_json = {}
 

--- a/Alerters/slack.py
+++ b/Alerters/slack.py
@@ -11,6 +11,7 @@ class SlackAlerter(Alerter):
     """Send alerts to a Slack webhook."""
 
     channel = None
+    username = None
 
     def __init__(self, config_options):
         if not requests_available:
@@ -49,7 +50,9 @@ class SlackAlerter(Alerter):
 
         host = "on host %s" % self.hostname
 
-        if self.username is not None:
+        if self.channel is not None:
+            message_json = {'channel': self.channel}
+        elif self.username is not None:
             message_json = {'username': self.username}
         else:
             message_json = {}


### PR DESCRIPTION
With the Slack webhook I am using, the channel is defined in the hook, so allow the alerter to run with no channel config.

Additionally support a username in the alert.

Changed some "none" to "None"