### PR TITLE
Fix Pushover - Include HTTPS protocol

### DIFF
--- a/Alerters/pushover.py
+++ b/Alerters/pushover.py
@@ -28,7 +28,7 @@ class PushoverAlerter(Alerter):
     def send_pushover_notification(self, subject, body):
         """Send a push notification."""
 
-        requests.post('api.pushover.net:443/1/messages.json',
+        requests.post('https://api.pushover.net/1/messages.json',
                       data={
                           "token": self.pushover_token,
                           "user": self.pushover_user,


### PR DESCRIPTION
Prevent error when using Python 3:

```
Couldn't send push notification: %s No connection adapters were found for 'api.pushover.net:443/1/messages.json'
```