### PR TITLE
Allowing 'ssl' to be absent in 'email' alerts

### DIFF
--- a/Alerters/mail.py
+++ b/Alerters/mail.py
@@ -51,7 +51,7 @@ class EMailAlerter(Alerter):
         self.ssl = Alerter.get_config_option(
             config_options,
             'ssl',
-            allowed_values=['starttls', 'yes']
+            allowed_values=['starttls', 'yes', None]
         )
         if self.ssl == 'yes':
             self.alerter_logger.warning('ssl=yes for email alerter is untested')


### PR DESCRIPTION
First of all, many thanks for creating this. It was exactly what I was looking for last night. I had one small error, so here is a fix.   };->

Fixing an error I was getting when using the **email** alerter

```
Traceback (most recent call last):
  File "monitor.py", line 477, in <module>
    main()
  File "monitor.py", line 349, in main
    m = load_alerters(m, config)
  File "monitor.py", line 211, in load_alerters
    new_alerter = Alerters.mail.EMailAlerter(config_options)
  File "/home/tschaller/simplemonitor/Alerters/mail.py", line 56, in __init__
    allow_empty=True
  File "/home/tschaller/simplemonitor/Alerters/alerter.py", line 145, in get_config_option
    return get_config_option(config_options, key, **kwargs)
  File "/home/tschaller/simplemonitor/util.py", line 73, in get_config_option
    raise exception('config option {0} needs to be one of {1}'.format(key, allowed_values))
util.AlerterConfigurationError: config option ssl needs to be one of ['starttls', 'yes']
```