### PR TITLE
Add (basic) implementation of an alerter that uses the Mac OS X Notification Center

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ monitor?.log
 monitor2.db
 _monitor-export/
 venv/
+env/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ monitor2.db
 _monitor-export/
 venv/
 env/
+*.vscode

--- a/Alerters/nc.py
+++ b/Alerters/nc.py
@@ -4,6 +4,8 @@ try:
 except ImportError:
     pync_available = False
 
+import platform
+
 from .alerter import Alerter
 
 class NotificationCenterAlerter(Alerter):
@@ -12,8 +14,12 @@ class NotificationCenterAlerter(Alerter):
     def __init__(self, config_options):
         Alerter.__init__(self, config_options)
         if not pync_available:
-            self.alerter_logger.critical("Pync package is not available, cannot use NotificationCenterAlerter.")
+            self.alerter_logger.critical("Pync package is not available, which is necessary to use NotificationCenterAlerter.")
             self.alerter_logger.critical("Try: pip install -r requirements.txt")
+            return
+
+        if platform.system() != "Darwin":
+            self.alerter_logger.critical("This alerter (currently) only works on Mac OS X!")
             return
 
     def send_alert(self, name, monitor):

--- a/Alerters/nc.py
+++ b/Alerters/nc.py
@@ -1,0 +1,29 @@
+try:
+    import pync
+    pync_available = True
+except ImportError:
+    pync_available = False
+
+from .alerter import Alerter
+
+class NotificationCenterAlerter(Alerter):
+    """Send alerts to the Mac OS X Notification Center."""
+
+    def __init__(self, config_options):
+        Alerter.__init__(self, config_options)
+        if not pync_available:
+            self.alerter_logger.critical("Pync package is not available, cannot use NotificationCenterAlerter.")
+            self.alerter_logger.critical("Try: pip install -r requirements.txt")
+            return
+
+    def send_alert(self, name, monitor):
+        """Send the message."""
+
+        type = self.should_alert(monitor)
+
+        if type == "":
+            return
+        elif type == "failure":
+            pync.notify('Monitor failed!', title="SimpleMonitor -{}".format(name))
+        else:
+            pass

--- a/Alerters/nc.py
+++ b/Alerters/nc.py
@@ -19,11 +19,20 @@ class NotificationCenterAlerter(Alerter):
     def send_alert(self, name, monitor):
         """Send the message."""
 
-        type = self.should_alert(monitor)
+        alert_type = self.should_alert(monitor)
+        message = ""
 
-        if type == "":
+        if alert_type == "":
             return
-        elif type == "failure":
-            pync.notify('Monitor failed!', title="SimpleMonitor -{}".format(name))
+        elif alert_type == "failure":
+            message = "Monitor {} failed!".format(name)
+        elif alert_type == "success":
+            message = "Monitor {} succeeded.".format(name)
         else:
-            pass
+            self.alerter_logger.error("Unknown alert type: {}".format(alert_type))
+            return
+
+        if not self.dry_run:
+            pync.notify(message=message, title="SimpleMonitor")
+        else:
+            self.alerter_logger.info("dry_run: would send message: {}".format(message))

--- a/monitor.py
+++ b/monitor.py
@@ -37,6 +37,7 @@ import Alerters.pushover
 import Alerters.nma
 import Alerters.pushbullet
 import Alerters.telegram
+import Alerters.nc
 
 try:
     import colorlog
@@ -230,6 +231,8 @@ def load_alerters(m, config):
             new_alerter = Alerters.pushbullet.PushbulletAlerter(config_options)
         elif alerter_type == "telegram":
             new_alerter = Alerters.telegram.TelegramAlerter(config_options)
+        elif alerter_type == "nc":
+            new_alerter = Alerters.nc.NotificationCenterAlerter(config_options)
         else:
             main_logger.error("Unknown alerter type %s", alerter_type)
             continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.10.0
 pyopenssl
 boto3>=1.3.1
 colorlog
+pync>=2.0.3


### PR DESCRIPTION
This PR introduces the option to alert to the Mac OS X Notification Center. It uses the _pync_ library to send messages.

It currently only works on Mac OS X. The alerter checks whether the current system is Mac OS X and if not, will log this and return.