### PR TITLE
JSON serialise compiled re objects safely

### DIFF
--- a/Loggers/network.py
+++ b/Loggers/network.py
@@ -91,8 +91,8 @@ class NetworkLogger(Logger):
                 s.send(send_bytes)
             finally:
                 s.close()
-        except Exception as e:
-            self.logger_logger.error("Failed to send network data: %s", e)
+        except Exception:
+            self.logger_logger.exception("Failed to send network data")
 
 
 class Listener(Thread):

--- a/Monitors/network.py
+++ b/Monitors/network.py
@@ -174,6 +174,8 @@ class MonitorHost(Monitor):
     ping_regexp = ""
     type = "host"
     time_regexp = ""
+    r = None
+    r2 = None
 
     def __init__(self, name, config_options):
         """
@@ -212,12 +214,16 @@ class MonitorHost(Monitor):
             'host',
             required=True
         )
-        self.r = re.compile(self.ping_regexp)
-        self.r2 = re.compile(self.time_regexp)
 
     def run_test(self):
         success = False
         pingtime = 0.0
+
+        if self.r is None:
+            self.monitor_logger.debug('Creating pre-compiled regexp')
+            self.r = re.compile(self.ping_regexp)
+            self.r2 = re.compile(self.time_regexp)
+
         try:
             cmd = (self.ping_command % self.host).split(' ')
             output = subprocess.check_output(cmd)

--- a/Monitors/network.py
+++ b/Monitors/network.py
@@ -174,8 +174,8 @@ class MonitorHost(Monitor):
     ping_regexp = ""
     type = "host"
     time_regexp = ""
-    r = None
-    r2 = None
+    r = ""
+    r2 = ""
 
     def __init__(self, name, config_options):
         """
@@ -219,7 +219,7 @@ class MonitorHost(Monitor):
         success = False
         pingtime = 0.0
 
-        if self.r is None:
+        if isinstance(self.r, str):
             self.monitor_logger.debug('Creating pre-compiled regexp')
             self.r = re.compile(self.ping_regexp)
             self.r2 = re.compile(self.time_regexp)

--- a/tests/network/client/monitors.ini
+++ b/tests/network/client/monitors.ini
@@ -1,2 +1,6 @@
 [test2]
 type=null
+
+[test3]
+type=host
+host=127.0.0.1

--- a/tests/test-network.sh
+++ b/tests/test-network.sh
@@ -22,6 +22,7 @@ run_test() {
 
 	# make sure the client reached the master
 	grep test2 network.log
+	grep test3 network.log
 
 	wait
 

--- a/util.py
+++ b/util.py
@@ -107,7 +107,7 @@ class JSONEncoder(json.JSONEncoder):
         if isinstance(obj, datetime.datetime):
             return {DATETIME_MAGIC_TOKEN: obj.strftime(FORMAT)}
         if isinstance(obj, self._regexp_type):
-            return None
+            return "<removed compiled regexp object>"
         return super(JSONEncoder, self).default(obj)
 
 

--- a/util.py
+++ b/util.py
@@ -101,10 +101,14 @@ FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
 
 class JSONEncoder(json.JSONEncoder):
+    _regexp_type = type(re.compile(''))
+
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
             return {DATETIME_MAGIC_TOKEN: obj.strftime(FORMAT)}
-        return super(JSONEncoder, self).default(self, obj)
+        if isinstance(obj, self._regexp_type):
+            return None
+        return super(JSONEncoder, self).default(obj)
 
 
 class JSONDecoder(json.JSONDecoder):


### PR DESCRIPTION
This commit fixes an issue reported by a user where
JSONEncoder.default() was called with too many params, and in the
process of fixing that revealed an issue where compiled re objects (as
generated by MonitorHost) can't be serialised.

Address it by serialising it to None, and having MonitorHost
re-initialise it if needed (although generally run_test() isn't called
on objects received over the network).

Fixes #187.