### PR TITLE
Fix count of remote monitors in HTMLLogger output

### DIFF
--- a/Loggers/file.py
+++ b/Loggers/file.py
@@ -202,7 +202,7 @@ class HTMLLogger(Logger):
         old_count = 0
         remote_count = 0
 
-        my_host = short_hostname
+        my_host = short_hostname()
 
         try:
             temp_file = tempfile.mkstemp()


### PR DESCRIPTION
The [refactoring in this commit](https://github.com/jamesoff/simplemonitor/commit/bde4ee62d2935c13b896f4ff8cda031ad605c4ea#diff-fe640f04be1a67e886ee00effc729f27R200) was missing parenthesis on the linked function call. This was causing all monitors to be counted as *remote* in the `HTMLLogger` output.