### PR TITLE
Added multiple email support

### DIFF
--- a/Alerters/mail.py
+++ b/Alerters/mail.py
@@ -125,7 +125,7 @@ class EMailAlerter(Alerter):
 
                 if self.username is not None:
                     server.login(self.username, self.password)
-                server.sendmail(self.from_addr, self.to_addr, message.as_string())
+                server.sendmail(self.from_addr, self.to_addr.split(';'), message.as_string())
                 server.quit()
             except Exception:
                 self.alerter_logger.exception("couldn't send mail")

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -75,7 +75,7 @@ delay=1
 
 | setting | description | required | default |
 |---|---|---|---|
-|host|the email server to send the message to (via SMTP).|yes| |
+|host|the email server to send the message to (via SMTP). You can set multiple addresses separated by ; .|yes| |
 |from|the email address the email should come from.|yes| |
 |to|the email address to email should go to.|yes| |
 |username|username to log into the SMTP server|no| |


### PR DESCRIPTION
Users can now define multiple mail addresses to be alerted.
Example:

`to=userA@mail.com;userB@mail.com`