### PR TITLE
Remove check for regexp and allowed_code

### DIFF
--- a/Monitors/network.py
+++ b/Monitors/network.py
@@ -38,15 +38,12 @@ class MonitorHTTP(Monitor):
         if regexp is not None:
             self.regexp = re.compile(regexp)
             self.regexp_text = regexp
-        if not regexp:
-            self.allowed_codes = Monitor.get_config_option(
-                config_options,
-                'allowed_codes',
-                default=[200],
-                required_type='[int]'
+        self.allowed_codes = Monitor.get_config_option(
+            config_options,
+            'allowed_codes',
+            default=[200],
+            required_type='[int]'
             )
-        else:
-            self.allowed_codes = [200]
 
         # optionnal - for HTTPS client authentication only
         # in this case, certfile is required


### PR DESCRIPTION
There's no need to only accept 200 when there's a regexp configured, people might want to check the content of other return values