### PR TITLE
Redo config options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
+os: linux
 dist: xenial
-sudo: required
 language: python
 python:
     - "3.5"
@@ -41,6 +41,6 @@ script:
     - travis_fold end network
 after_success:
     - pipenv run codecov
-matrix:
+jobs:
     allow_failures:
         - python: nightly

--- a/simplemonitor/Alerters/alerter.py
+++ b/simplemonitor/Alerters/alerter.py
@@ -30,25 +30,23 @@ class Alerter:
     def __init__(self, config_options: dict = None) -> None:
         if config_options is None:
             config_options = {}
+        self._config_options = config_options
         self.alerter_logger = logging.getLogger("simplemonitor.alerter-" + self.type)
         self.available = True
         self.dependencies = cast(
             List[str],
-            Alerter.get_config_option(
-                config_options, "depend", required_type="[str]", default=[]
-            ),
+            self.get_config_option("depend", required_type="[str]", default=[]),
         )
-        self.limit = Alerter.get_config_option(
-            config_options, "limit", required_type="int", minimum=1, default=1
+        self.limit = self.get_config_option(
+            "limit", required_type="int", minimum=1, default=1
         )
-        self.repeat = Alerter.get_config_option(
-            config_options, "repeat", required_type="int", default=0, minimum=0
+        self.repeat = self.get_config_option(
+            "repeat", required_type="int", default=0, minimum=0
         )
-        self._groups = Alerter.get_config_option(
-            config_options, "groups", required_type="[str]", default=["default"]
+        self._groups = self.get_config_option(
+            "groups", required_type="[str]", default=["default"]
         )
-        self.times_type = Alerter.get_config_option(
-            config_options,
+        self.times_type = self.get_config_option(
             "times_type",
             required_type="str",
             allowed_values=["always", "only", "not"],
@@ -60,14 +58,10 @@ class Alerter:
         )  # type: Tuple[Optional[datetime.time], Optional[datetime.time]]
         if self.times_type in ["only", "not"]:
             time_lower = str(
-                Alerter.get_config_option(
-                    config_options, "time_lower", required_type="str", required=True
-                )
+                self.get_config_option("time_lower", required_type="str", required=True)
             )
             time_upper = str(
-                Alerter.get_config_option(
-                    config_options, "time_upper", required_type="str", required=True
-                )
+                self.get_config_option("time_upper", required_type="str", required=True)
             )
             try:
                 time_info = [
@@ -81,38 +75,34 @@ class Alerter:
                 self.time_info = (time_info[0], time_info[1])
             except Exception:
                 raise RuntimeError("error processing time limit definition")
-        self.days = Alerter.get_config_option(
-            config_options,
+        self.days = self.get_config_option(
             "days",
             required_type="[int]",
             allowed_values=list(range(0, 7)),
             default=list(range(0, 7)),
         )
-        self.delay_notification = Alerter.get_config_option(
-            config_options, "delay", required_type="bool", default=False
+        self.delay_notification = self.get_config_option(
+            "delay", required_type="bool", default=False
         )
-        self.dry_run = Alerter.get_config_option(
-            config_options, "dry_run", required_type="bool", default=False
+        self.dry_run = self.get_config_option(
+            "dry_run", required_type="bool", default=False
         )
-        self.ooh_recovery = Alerter.get_config_option(
-            config_options, "ooh_recovery", required_type="bool", default=False
+        self.ooh_recovery = self.get_config_option(
+            "ooh_recovery", required_type="bool", default=False
         )
 
-        if Alerter.get_config_option(
-            config_options, "debug_times", required_type=bool, default=False
-        ):
+        if self.get_config_option("debug_times", required_type=bool, default=False):
             self.time_info = (
                 (datetime.datetime.utcnow() - datetime.timedelta(minutes=1)).time(),
                 (datetime.datetime.utcnow() + datetime.timedelta(minutes=1)).time(),
             )
             self.alerter_logger.debug("set times for alerter to %s", self.time_info)
 
-    @staticmethod
     def get_config_option(
-        config_options: dict, key: str, **kwargs: Any
+        self, key: str, **kwargs: Any
     ) -> Union[None, str, int, float, bool, List[str], List[int]]:
         kwargs["exception"] = AlerterConfigurationError
-        return get_config_option(config_options, key, **kwargs)
+        return get_config_option(self._config_options, key, **kwargs)
 
     @property
     def dependencies(self) -> List[str]:

--- a/simplemonitor/Alerters/bulksms.py
+++ b/simplemonitor/Alerters/bulksms.py
@@ -17,28 +17,22 @@ class BulkSMSAlerter(Alerter):
     type = "bulksms"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
-        self.username = Alerter.get_config_option(
-            config_options, "username", required=True, allow_empty=False
+        super().__init__(config_options)
+        self.username = self.get_config_option(
+            "username", required=True, allow_empty=False
         )
-        self.password = Alerter.get_config_option(
-            config_options, "password", required=True, allow_empty=False
+        self.password = self.get_config_option(
+            "password", required=True, allow_empty=False
         )
-        self.target = Alerter.get_config_option(
-            config_options, "target", required=True, allow_empty=False
-        )
+        self.target = self.get_config_option("target", required=True, allow_empty=False)
 
-        self.sender = Alerter.get_config_option(
-            config_options, "sender", default="SmplMntr"
-        )
+        self.sender = self.get_config_option("sender", default="SmplMntr")
         assert isinstance(self.sender, str)
         if len(self.sender) > 11:
             self.alerter_logger.warning("truncating SMS sender name to 11 chars")
             self.sender = self.sender[:11]
 
-        self.api_host = Alerter.get_config_option(
-            config_options, "api_host", default="www.bulksms.co.uk"
-        )
+        self.api_host = self.get_config_option("api_host", default="www.bulksms.co.uk")
 
         self.support_catchup = True
 

--- a/simplemonitor/Alerters/execute.py
+++ b/simplemonitor/Alerters/execute.py
@@ -15,25 +15,16 @@ class ExecuteAlerter(Alerter):
     type = "execute"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
 
         self.fail_command = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "fail_command", allow_empty=False
-            ),
+            str, self.get_config_option("fail_command", allow_empty=False)
         )
         self.success_command = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "success_command", allow_empty=False
-            ),
+            str, self.get_config_option("success_command", allow_empty=False)
         )
         self.catchup_command = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "catchup_command", allow_empty=False
-            ),
+            str, self.get_config_option("catchup_command", allow_empty=False)
         )
         if (
             self.fail_command is None

--- a/simplemonitor/Alerters/fortysixelks.py
+++ b/simplemonitor/Alerters/fortysixelks.py
@@ -21,7 +21,7 @@ class FortySixElksAlerter(Alerter):
     type = "46elks"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
         if not requests_available:
             self.alerter_logger.critical(
                 "Requests package is not available, cannot use FortySixElksAlerter."
@@ -30,27 +30,16 @@ class FortySixElksAlerter(Alerter):
             return
 
         self.username = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "username", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("username", required=True, allow_empty=False)
         )
         self.password = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "password", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("password", required=True, allow_empty=False)
         )
         self.target = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "target", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("target", required=True, allow_empty=False)
         )
 
-        self.sender = cast(
-            str, Alerter.get_config_option(config_options, "sender", default="SmplMntr")
-        )
+        self.sender = cast(str, self.get_config_option("sender", default="SmplMntr"))
         if self.sender[0] == "+" and self.sender[1:].isdigit():
             # sender is phone number
             pass
@@ -62,9 +51,7 @@ class FortySixElksAlerter(Alerter):
             self.alerter_logger.warning("truncating SMS sender name to 11 chars")
             self.sender = self.sender[:11]
 
-        self.api_host = Alerter.get_config_option(
-            config_options, "api_host", default="api.46elks.com"
-        )
+        self.api_host = self.get_config_option("api_host", default="api.46elks.com")
 
         self.support_catchup = True
 

--- a/simplemonitor/Alerters/mail.py
+++ b/simplemonitor/Alerters/mail.py
@@ -16,38 +16,24 @@ class EMailAlerter(Alerter):
     type = "email"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
         self.mail_host = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "host", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("host", required=True, allow_empty=False)
         )
         self.from_addr = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "from", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("from", required=True, allow_empty=False)
         )
         self.to_addr = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "to", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("to", required=True, allow_empty=False)
         )
         self.mail_port = cast(
-            int,
-            Alerter.get_config_option(
-                config_options, "port", required_type="int", default=25
-            ),
+            int, self.get_config_option("port", required_type="int", default=25)
         )
-        self.username = cast(str, Alerter.get_config_option(config_options, "username"))
-        self.password = cast(str, Alerter.get_config_option(config_options, "password"))
+        self.username = cast(str, self.get_config_option("username"))
+        self.password = cast(str, self.get_config_option("password"))
         self.ssl = cast(
             Optional[str],
-            Alerter.get_config_option(
-                config_options, "ssl", allowed_values=["starttls", "yes", None]
-            ),
+            self.get_config_option("ssl", allowed_values=["starttls", "yes", None]),
         )
         if self.ssl == "yes":
             self.alerter_logger.warning("ssl=yes for email alerter is untested")

--- a/simplemonitor/Alerters/nc.py
+++ b/simplemonitor/Alerters/nc.py
@@ -18,7 +18,7 @@ class NotificationCenterAlerter(Alerter):
     type = "nc"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
         if not pync_available:
             self.alerter_logger.critical(
                 "Pync package is not available, which is necessary to use NotificationCenterAlerter."

--- a/simplemonitor/Alerters/pushbullet.py
+++ b/simplemonitor/Alerters/pushbullet.py
@@ -14,13 +14,10 @@ class PushbulletAlerter(Alerter):
     type = "pushbullet"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
 
         self.pushbullet_token = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "token", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("token", required=True, allow_empty=False)
         )
 
         self.support_catchup = True

--- a/simplemonitor/Alerters/pushover.py
+++ b/simplemonitor/Alerters/pushover.py
@@ -15,19 +15,13 @@ class PushoverAlerter(Alerter):
     type = "pushover"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
 
         self.pushover_token = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "token", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("token", required=True, allow_empty=False)
         )
         self.pushover_user = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "user", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("user", required=True, allow_empty=False)
         )
 
         self.support_catchup = True

--- a/simplemonitor/Alerters/ses.py
+++ b/simplemonitor/Alerters/ses.py
@@ -21,7 +21,7 @@ class SESAlerter(Alerter):
     type = "ses"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
         if not boto3_available:
             self.alerter_logger.critical(
                 "boto3 package is not available, cannot use SESAlerter."
@@ -29,27 +29,19 @@ class SESAlerter(Alerter):
             self.available = False
             return
 
-        self.from_addr = cast(
-            str, Alerter.get_config_option(config_options, "from", allow_empty=False)
-        )
-        self.to_addr = cast(
-            str, Alerter.get_config_option(config_options, "to", allow_empty=False)
-        )
+        self.from_addr = cast(str, self.get_config_option("from", allow_empty=False))
+        self.to_addr = cast(str, self.get_config_option("to", allow_empty=False))
 
         self.support_catchup = True
 
         self.ses_client_params = {}  # type: Dict[str, str]
 
-        aws_region = cast(str, Alerter.get_config_option(config_options, "aws_region"))
+        aws_region = cast(str, self.get_config_option("aws_region"))
         if aws_region:
             os.environ["AWS_DEFAULT_REGION"] = aws_region
 
-        aws_access_key = cast(
-            str, Alerter.get_config_option(config_options, "aws_access_key")
-        )
-        aws_secret_key = cast(
-            str, Alerter.get_config_option(config_options, "aws_secret_access_key")
-        )
+        aws_access_key = cast(str, self.get_config_option("aws_access_key"))
+        aws_secret_key = cast(str, self.get_config_option("aws_secret_access_key"))
 
         if aws_access_key and aws_secret_key:
             self.ses_client_params["aws_access_key_id"] = aws_access_key

--- a/simplemonitor/Alerters/slack.py
+++ b/simplemonitor/Alerters/slack.py
@@ -22,7 +22,7 @@ class SlackAlerter(Alerter):
     username = None
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
         if not requests_available:
             self.alerter_logger.critical(
                 "Requests package is not available, cannot use SlackAlerter."
@@ -31,14 +31,11 @@ class SlackAlerter(Alerter):
             return
 
         self.url = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "url", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("url", required=True, allow_empty=False)
         )
 
-        self.channel = cast(str, Alerter.get_config_option(config_options, "channel"))
-        self.username = cast(str, Alerter.get_config_option(config_options, "username"))
+        self.channel = cast(str, self.get_config_option("channel"))
+        self.username = cast(str, self.get_config_option("username"))
 
     def send_alert(self, name: str, monitor: Monitor) -> None:
         """Send the message."""

--- a/simplemonitor/Alerters/telegram.py
+++ b/simplemonitor/Alerters/telegram.py
@@ -15,20 +15,14 @@ class TelegramAlerter(Alerter):
     type = "telegram"
 
     def __init__(self, config_options: dict) -> None:
-        Alerter.__init__(self, config_options)
+        super().__init__(config_options)
 
         self.telegram_token = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "token", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("token", required=True, allow_empty=False)
         )
 
         self.telegram_chatid = cast(
-            str,
-            Alerter.get_config_option(
-                config_options, "chat_id", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("chat_id", required=True, allow_empty=False)
         )
 
         self.support_catchup = True

--- a/simplemonitor/Loggers/db.py
+++ b/simplemonitor/Loggers/db.py
@@ -50,11 +50,11 @@ class DBLogger(Logger):
 
     def __init__(self, config_options: dict) -> None:
         """Open the database connection."""
-        Logger.__init__(self, config_options)
+        super().__init__(config_options)
         if not sqlite_available:
             raise RuntimeError("SQLite module not loaded.")
-        self.db_path = Logger.get_config_option(
-            config_options, "db_path", required=True, allow_empty=False
+        self.db_path = self.get_config_option(
+            "db_path", required=True, allow_empty=False
         )
 
         self.db_handle = sqlite3.connect(self.db_path, isolation_level=None)

--- a/simplemonitor/Loggers/file.py
+++ b/simplemonitor/Loggers/file.py
@@ -28,34 +28,29 @@ class FileLogger(Logger):
     def __init__(self, config_options: dict = None) -> None:
         if config_options is None:
             config_options = {}
-        Logger.__init__(self, config_options)
-        if "filename" in config_options:
-            try:
-                self.filename = config_options["filename"]
-                self.file_handle = open(self.filename, "a+")
-            except Exception as e:
-                raise RuntimeError(
-                    "Couldn't open log file %s for appending: %s" % (self.filename, e)
-                )
-        else:
-            raise RuntimeError("Missing filename for logfile")
-        self.filename = Logger.get_config_option(
-            config_options, "filename", required=True, allow_empty=False
+        super().__init__(config_options)
+        self.filename = self.get_config_option(
+            "filename", required=True, allow_empty=False
         )
+        try:
+            self.file_handle = open(self.filename, "a+")
+        except Exception as e:
+            raise RuntimeError(
+                "Couldn't open log file %s for appending: %s" % (self.filename, e)
+            )
         self.file_handle = open(self.filename, "a+")
 
-        self.only_failures = Logger.get_config_option(
-            config_options, "only_failures", required_type="bool", default=False
+        self.only_failures = self.get_config_option(
+            "only_failures", required_type="bool", default=False
         )
 
-        self.buffered = Logger.get_config_option(
-            config_options, "buffered", required_type="bool", default=True
+        self.buffered = self.get_config_option(
+            "buffered", required_type="bool", default=True
         )
 
         self.dateformat = cast(
             str,
-            Logger.get_config_option(
-                config_options,
+            self.get_config_option(
                 "dateformat",
                 required_type="str",
                 allowed_values=["timestamp", "iso8601"],
@@ -130,45 +125,28 @@ class HTMLLogger(Logger):
             os.path.dirname(sys.modules["simplemonitor"].__file__), "html"
         )
         self.filename = cast(
-            str,
-            Logger.get_config_option(
-                config_options, "filename", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("filename", required=True, allow_empty=False)
         )
         self.header = cast(
             str,
-            Logger.get_config_option(
-                config_options,
-                "header",
-                required=False,
-                allow_empty=False,
-                default="header.html",
+            self.get_config_option(
+                "header", required=False, allow_empty=False, default="header.html"
             ),
         )
         self.footer = cast(
             str,
-            Logger.get_config_option(
-                config_options,
-                "footer",
-                required=False,
-                allow_empty=False,
-                default="footer.html",
+            self.get_config_option(
+                "footer", required=False, allow_empty=False, default="footer.html"
             ),
         )
         self.source_folder = cast(
             str,
-            super().get_config_option(
-                config_options,
-                "source_folder",
-                required=False,
-                default=package_data_dir,
+            self.get_config_option(
+                "source_folder", required=False, default=package_data_dir
             ),
         )
         self.folder = cast(
-            str,
-            Logger.get_config_option(
-                config_options, "folder", required=False, default="html"
-            ),
+            str, self.get_config_option("folder", required=False, default="html")
         )
         if not os.path.isdir(self.folder):
             self.logger_logger.critical(
@@ -176,15 +154,13 @@ class HTMLLogger(Logger):
             )
         self.copy_resources = cast(
             bool,
-            super().get_config_option(
-                config_options, "copy_resources", required_type="bool", default=True
+            self.get_config_option(
+                "copy_resources", required_type="bool", default=True
             ),
         )
         self.upload_command = cast(
             str,
-            Logger.get_config_option(
-                config_options, "upload_command", required=False, allow_empty=False
-            ),
+            self.get_config_option("upload_command", required=False, allow_empty=False),
         )
         self._resource_files = ["style.css"]  # type: List[str]
 
@@ -449,8 +425,8 @@ class JsonLogger(Logger):
         if config_options is None:
             config_options = {}
         super().__init__(config_options)
-        self.filename = Logger.get_config_option(
-            config_options, "filename", required=True, allow_empty=False
+        self.filename = self.get_config_option(
+            "filename", required=True, allow_empty=False
         )
 
     def save_result2(self, name: str, monitor: Monitor) -> None:

--- a/simplemonitor/Loggers/logger.py
+++ b/simplemonitor/Loggers/logger.py
@@ -17,21 +17,19 @@ class Logger:
     connected = True
 
     def __init__(self, config_options: dict) -> None:
-        self.name = Logger.get_config_option(config_options, "_name", default="unnamed")
+        self._config_options = config_options
+        self.name = self.get_config_option("_name", default="unnamed")
         self.logger_logger = logging.getLogger("simplemonitor.logger-" + self.name)
         self._dependencies = cast(
             List[str],
-            Logger.get_config_option(
-                config_options, "depend", required_type="[str]", default=[]
-            ),
+            self.get_config_option("depend", required_type="[str]", default=[]),
         )
         if self.batch_data is None:
             self.batch_data = {}
 
-    @staticmethod
-    def get_config_option(config_options: dict, key: str, **kwargs: Any) -> Any:
+    def get_config_option(self, key: str, **kwargs: Any) -> Any:
         kwargs["exception"] = LoggerConfigurationError
-        return get_config_option(config_options, key, **kwargs)
+        return get_config_option(self._config_options, key, **kwargs)
 
     def hup(self) -> None:
         """Close and reopen our log file, if supported.

--- a/simplemonitor/Loggers/mqtt.py
+++ b/simplemonitor/Loggers/mqtt.py
@@ -29,7 +29,7 @@ class MQTTLogger(Logger):
     def __init__(self, config_options: dict = None) -> None:
         if config_options is None:
             config_options = {}
-        Logger.__init__(self, config_options)
+        super().__init__(config_options)
 
         if not mqtt_available:
             self.logger_logger.error("Missing paho.mqtt module!")
@@ -37,15 +37,11 @@ class MQTTLogger(Logger):
 
         # TODO: add configuration for authenticated calls, port, will, etc.
         self.host = cast(
-            str,
-            Logger.get_config_option(
-                config_options, "host", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("host", required=True, allow_empty=False)
         )
         self.port = cast(
             int,
-            Logger.get_config_option(
-                config_options,
+            self.get_config_option(
                 "port",
                 required=False,
                 allow_empty=False,
@@ -57,8 +53,7 @@ class MQTTLogger(Logger):
         # https://www.home-assistant.io/docs/mqtt/discovery/
         self.hass = cast(
             bool,
-            Logger.get_config_option(
-                config_options,
+            self.get_config_option(
                 "hass",
                 required=False,
                 allow_empty=False,
@@ -69,8 +64,7 @@ class MQTTLogger(Logger):
         # topic to send information to
         self.topic = cast(
             str,
-            Logger.get_config_option(
-                config_options,
+            self.get_config_option(
                 "topic",
                 required=False,
                 allow_empty=False,

--- a/simplemonitor/Loggers/network.py
+++ b/simplemonitor/Loggers/network.py
@@ -28,26 +28,17 @@ class NetworkLogger(Logger):
     supports_batch = True
 
     def __init__(self, config_options: dict) -> None:
-        Logger.__init__(self, config_options)
+        super().__init__(config_options)
 
         self.host = cast(
-            str,
-            Logger.get_config_option(
-                config_options, "host", required=True, allow_empty=False
-            ),
+            str, self.get_config_option("host", required=True, allow_empty=False)
         )
         self.port = cast(
-            int,
-            Logger.get_config_option(
-                config_options, "port", required_type="int", required=True
-            ),
+            int, self.get_config_option("port", required_type="int", required=True)
         )
         self.hostname = socket.gethostname()
         self.key = bytearray(
-            Logger.get_config_option(
-                config_options, "key", required=True, allow_empty=False
-            ),
-            "utf-8",
+            self.get_config_option("key", required=True, allow_empty=False), "utf-8"
         )
 
     def describe(self) -> str:

--- a/simplemonitor/Monitors/compound.py
+++ b/simplemonitor/Monitors/compound.py
@@ -19,25 +19,17 @@ class CompoundMonitor(Monitor):
     mt = None  # type: Optional[WeakValueDictionary[str, Monitor]]
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
+        super().__init__(name, config_options)
         self.monitors = cast(
             List[str],
-            Monitor.get_config_option(
-                config_options,
-                "monitors",
-                required_type="[str]",
-                required=True,
-                default=[],
+            self.get_config_option(
+                "monitors", required_type="[str]", required=True, default=[]
             ),
         )
         self.min_fail = cast(
             int,
-            Monitor.get_config_option(
-                config_options,
-                "min_fail",
-                required_type="int",
-                default=len(self.monitors),
-                minimum=1,
+            self.get_config_option(
+                "min_fail", required_type="int", default=len(self.monitors), minimum=1
             ),
         )
 

--- a/simplemonitor/Monitors/hass.py
+++ b/simplemonitor/Monitors/hass.py
@@ -13,16 +13,10 @@ class MonitorSensor(Monitor):
     type = "hass_sensor"
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.url = cast(
-            str, Monitor.get_config_option(config_options, "url", required=True)
-        )
-        self.sensor = cast(
-            str, Monitor.get_config_option(config_options, "sensor", required=True)
-        )
-        self.token = cast(
-            str, Monitor.get_config_option(config_options, "token", default=None)
-        )
+        super().__init__(name, config_options)
+        self.url = cast(str, self.get_config_option("url", required=True))
+        self.sensor = cast(str, self.get_config_option("sensor", required=True))
+        self.token = cast(str, self.get_config_option("token", default=None))
 
     def describe(self) -> str:
         return "monitor the existence of a sensor"

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -61,7 +61,7 @@ class MonitorDiskSpace(Monitor):
     type = "diskspace"
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
+        super().__init__(name, config_options)
         if self.is_windows(allow_cygwin=False):
             self.use_statvfs = False
             if not win32_available:
@@ -70,11 +70,9 @@ class MonitorDiskSpace(Monitor):
                 )
         else:
             self.use_statvfs = True
-        self.partition = Monitor.get_config_option(
-            config_options, "partition", required=True
-        )
+        self.partition = self.get_config_option("partition", required=True)
         self.limit = _size_string_to_bytes(
-            Monitor.get_config_option(config_options, "limit", required=True)
+            self.get_config_option("limit", required=True)
         )
 
     def run_test(self) -> bool:
@@ -118,26 +116,26 @@ class MonitorFileStat(Monitor):
     type = "filestat"
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.maxage = Monitor.get_config_option(
-            config_options, "maxage", required_type="int", minimum=0
+        super().__init__(name, config_options)
+        self.maxage = self.get_config_option(
+            "maxage", required_type="int", minimum=0
         )
-        _minsize = Monitor.get_config_option(
-            config_options, "minsize", required_type="str", allow_empty=True
+        _minsize = self.get_config_option(
+            "minsize", required_type="str", allow_empty=True
         )
         if _minsize:
             self.minsize = _size_string_to_bytes(_minsize)
         else:
             self.minsize = None
-        _maxsize = Monitor.get_config_option(
-            config_options, "maxsize", required_type="str", allow_empty=True, default=""
+        _maxsize = self.get_config_option(
+            "maxsize", required_type="str", allow_empty=True, default=""
         )
         if _maxsize:
             self.maxsize = _size_string_to_bytes(_maxsize)
         else:
             self.maxsize = None
-        self.filename = Monitor.get_config_option(
-            config_options, "filename", required=True
+        self.filename = self.get_config_option(
+            "filename", required=True
         )
 
     def run_test(self) -> bool:
@@ -200,8 +198,8 @@ class MonitorApcupsd(Monitor):
     type = "apcupsd"
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.path = Monitor.get_config_option(config_options, "path", default="")
+        super().__init__(name, config_options)
+        self.path = self.get_config_option("path", default="")
 
     def run_test(self) -> bool:
         info = {}
@@ -263,8 +261,8 @@ class MonitorPortAudit(Monitor):
     regexp = re.compile(r"(\d+) problem\(s\) in your installed packages found")
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.path = Monitor.get_config_option(config_options, "path", default="")
+        super().__init__(name, config_options)
+        self.path = self.get_config_option("path", default="")
 
     def describe(self) -> str:
         return "Checking for insecure ports."
@@ -312,8 +310,8 @@ class MonitorPkgAudit(Monitor):
     path = ""
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.path = Monitor.get_config_option(config_options, "path", default="")
+        super().__init__(name, config_options)
+        self.path = self.get_config_option("path", default="")
 
     def describe(self) -> str:
         return "Checking for insecure packages."
@@ -358,20 +356,15 @@ class MonitorLoadAvg(Monitor):
     type = "loadavg"
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
+        super().__init__(name, config_options)
         if self.is_windows(allow_cygwin=False):
             raise RuntimeError("loadavg monitor does not support Windows")
         # which time field we're looking at: 0 = 1min, 1 = 5min, 2=15min
-        self.which = Monitor.get_config_option(
-            config_options,
-            "which",
-            required_type="int",
-            default=1,
-            minimum=0,
-            maximum=2,
+        self.which = self.get_config_option(
+            "which", required_type="int", default=1, minimum=0, maximum=2
         )
-        self.max = Monitor.get_config_option(
-            config_options, "max", required_type="float", default=1.00, minimum=0
+        self.max = self.get_config_option(
+            "max", required_type="float", default=1.00, minimum=0
         )
 
     def describe(self) -> str:
@@ -435,9 +428,9 @@ class MonitorZap(Monitor):
     r = re.compile("^alarms=(?P<status>).+")
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.span = Monitor.get_config_option(
-            config_options, "span", required_type="int", default=1, minimum=1
+        super().__init__(name, config_options)
+        self.span = self.get_config_option(
+            "span", required_type="int", default=1, minimum=1
         )
 
     def run_test(self) -> bool:
@@ -474,14 +467,10 @@ class MonitorCommand(Monitor):
     available = True
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
+        super().__init__(name, config_options)
 
-        self.result_regexp_text = Monitor.get_config_option(
-            config_options, "result_regexp", default=""
-        )
-        self.result_max = Monitor.get_config_option(
-            config_options, "result_max", required_type="int"
-        )
+        self.result_regexp_text = self.get_config_option("result_regexp", default="")
+        self.result_max = self.get_config_option("result_max", required_type="int")
         if self.result_regexp_text != "":
             self.result_regexp = re.compile(self.result_regexp_text)
             if self.result_max is not None:
@@ -490,9 +479,7 @@ class MonitorCommand(Monitor):
                 )
                 self.result_max = None
 
-        command = Monitor.get_config_option(
-            config_options, "command", required=True, allow_empty=False
-        )
+        command = self.get_config_option("command", required=True, allow_empty=False)
         self.command = shlex.split(command)
 
     def run_test(self) -> bool:

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -117,9 +117,7 @@ class MonitorFileStat(Monitor):
 
     def __init__(self, name: str, config_options: dict) -> None:
         super().__init__(name, config_options)
-        self.maxage = self.get_config_option(
-            "maxage", required_type="int", minimum=0
-        )
+        self.maxage = self.get_config_option("maxage", required_type="int", minimum=0)
         _minsize = self.get_config_option(
             "minsize", required_type="str", allow_empty=True
         )
@@ -134,9 +132,7 @@ class MonitorFileStat(Monitor):
             self.maxsize = _size_string_to_bytes(_maxsize)
         else:
             self.maxsize = None
-        self.filename = self.get_config_option(
-            "filename", required=True
-        )
+        self.filename = self.get_config_option("filename", required=True)
 
     def run_test(self) -> bool:
         try:
@@ -399,9 +395,7 @@ class MonitorMemory(Monitor):
         super().__init__(name, config_options)
         self.percent_free = cast(
             int,
-            self.get_config_option(
-                config_options, "percent_free", required_type="int", required=True
-            ),
+            self.get_config_option("percent_free", required_type="int", required=True),
         )
 
     def run_test(self) -> bool:

--- a/simplemonitor/Monitors/monitor.py
+++ b/simplemonitor/Monitors/monitor.py
@@ -51,47 +51,41 @@ class Monitor:
         """What's that coming over the hill? Is a monitor?"""
         if config_options is None:
             config_options = {}
+        self._config_options = config_options
         self.name = name
         self._deps = []  # type: List[str]
         self.monitor_logger = logging.getLogger("simplemonitor.monitor-" + self.name)
-        self._dependencies = Monitor.get_config_option(
-            config_options, "depend", required_type="[str]", default=list()
+        self._dependencies = self.get_config_option(
+            "depend", required_type="[str]", default=list()
         )
-        self._urgent = Monitor.get_config_option(
-            config_options, "urgent", required_type="bool", default=True
+        self._urgent = self.get_config_option(
+            "urgent", required_type="bool", default=True
         )
-        self._notify = Monitor.get_config_option(
-            config_options, "notify", required_type="bool", default=True
+        self._notify = self.get_config_option(
+            "notify", required_type="bool", default=True
         )
-        self.group = Monitor.get_config_option(
-            config_options, "group", default="default"
+        self.group = self.get_config_option("group", default="default")
+        self._tolerance = self.get_config_option(
+            "tolerance", required_type="int", default=0, minimum=0
         )
-        self._tolerance = Monitor.get_config_option(
-            config_options, "tolerance", required_type="int", default=0, minimum=0
+        self.remote_alerting = self.get_config_option(
+            "remote_alert", required_type="bool", default=False
         )
-        self.remote_alerting = Monitor.get_config_option(
-            config_options, "remote_alert", required_type="bool", default=False
-        )
-        self._recover_command = Monitor.get_config_option(
-            config_options, "recover_command"
-        )
-        self._recovered_command = Monitor.get_config_option(
-            config_options, "recovered_command"
-        )
+        self._recover_command = self.get_config_option("recover_command")
+        self._recovered_command = self.get_config_option("recovered_command")
         self.recover_info = ""
         self.recovered_info = ""
-        self.minimum_gap = Monitor.get_config_option(
-            config_options, "gap", required_type="int", minimum=0, default=0
+        self.minimum_gap = self.get_config_option(
+            "gap", required_type="int", minimum=0, default=0
         )
 
         self.running_on = short_hostname()
         self.was_skipped = False
         self._last_run = 0
 
-    @staticmethod
-    def get_config_option(config_options: dict, key: str, **kwargs: Any) -> Any:
+    def get_config_option(self, key: str, **kwargs: Any) -> Any:
         kwargs["exception"] = MonitorConfigurationError
-        return get_config_option(config_options, key, **kwargs)
+        return get_config_option(self._config_options, key, **kwargs)
 
     @property
     def dependencies(self) -> List[str]:
@@ -441,8 +435,8 @@ class MonitorFail(Monitor):
 
     def __init__(self, name: str, config_options: dict):
         Monitor.__init__(self, name, config_options)
-        self.interval = Monitor.get_config_option(
-            config_options, "interval", required_type="int", minimum=1, default=5
+        self.interval = self.get_config_option(
+            "interval", required_type="int", minimum=1, default=5
         )
 
     def run_test(self) -> bool:

--- a/simplemonitor/Monitors/network.py
+++ b/simplemonitor/Monitors/network.py
@@ -34,16 +34,16 @@ class MonitorHTTP(Monitor):
     headers = None
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.url = Monitor.get_config_option(config_options, "url", required=True)
+        super().__init__(name, config_options)
+        self.url = self.get_config_option("url", required=True)
 
-        regexp = Monitor.get_config_option(config_options, "regexp")
+        regexp = self.get_config_option("regexp")
         if regexp is not None:
             self.regexp = re.compile(regexp)
             self.regexp_text = regexp
         if not regexp:
-            self.allowed_codes = Monitor.get_config_option(
-                config_options, "allowed_codes", default=[200], required_type="[int]"
+            self.allowed_codes = self.get_config_option(
+                "allowed_codes", default=[200], required_type="[int]"
             )
         else:
             self.allowed_codes = [200]
@@ -61,12 +61,12 @@ class MonitorHTTP(Monitor):
         if self.headers:
             self.headers = json.loads(self.headers)
 
-        self.verify_hostname = Monitor.get_config_option(
-            config_options, "verify_hostname", default=True, required_type="bool"
+        self.verify_hostname = self.get_config_option(
+            "verify_hostname", default=True, required_type="bool"
         )
 
-        self.request_timeout = Monitor.get_config_option(
-            config_options, "timeout", default=5, required_type="int"
+        self.request_timeout = self.get_config_option(
+            "timeout", default=5, required_type="int"
         )
 
         self.username = config_options.get("username")
@@ -163,12 +163,12 @@ class MonitorTCP(Monitor):
 
     def __init__(self, name: str, config_options: dict) -> None:
         """Constructor"""
-        Monitor.__init__(self, name, config_options)
-        self.host = Monitor.get_config_option(config_options, "host", required=True)
+        super().__init__(name, config_options)
+        self.host = self.get_config_option("host", required=True)
         self.port = cast(
             int,
-            Monitor.get_config_option(
-                config_options, "port", required=True, required_type="int", minimum=0
+            self.get_config_option(
+                "port", required=True, required_type="int", minimum=0
             ),
         )
 
@@ -209,9 +209,9 @@ class MonitorHost(Monitor):
         This is to stop ping holding things up too much. A machine that can't ping back in <5s is
         a machine in trouble anyway, so should probably count as a failure.
         """
-        Monitor.__init__(self, name, config_options)
-        ping_ttl = Monitor.get_config_option(
-            config_options, "ping_ttl", required_type="int", minimum=0, default=5
+        super().__init__(name, config_options)
+        ping_ttl = self.get_config_option(
+            "ping_ttl", required_type="int", minimum=0, default=5
         )
         ping_ms = str(ping_ttl * 1000)
         ping_ttl = str(ping_ttl)
@@ -231,7 +231,7 @@ class MonitorHost(Monitor):
         else:
             RuntimeError("Don't know how to run ping on this platform, help!")
 
-        self.host = Monitor.get_config_option(config_options, "host", required=True)
+        self.host = self.get_config_option("host", required=True)
 
     def run_test(self) -> bool:
         success = False
@@ -279,19 +279,19 @@ class MonitorDNS(Monitor):
     command = "dig"
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.path = Monitor.get_config_option(config_options, "record", required=True)
+        super().__init__(name, config_options)
+        self.path = self.get_config_option("record", required=True)
 
-        self.desired_val = Monitor.get_config_option(config_options, "desired_val")
+        self.desired_val = self.get_config_option("desired_val")
 
-        self.server = Monitor.get_config_option(config_options, "server")
+        self.server = self.get_config_option("server")
 
         self.params = [self.command]
 
         if self.server:
             self.params.append("@%s" % self.server)
 
-        self.rectype = Monitor.get_config_option(config_options, "record_type")
+        self.rectype = self.get_config_option("record_type")
         if self.rectype:
             self.params.append("-t")
             self.params.append(config_options["record_type"])

--- a/simplemonitor/Monitors/ring.py
+++ b/simplemonitor/Monitors/ring.py
@@ -26,25 +26,15 @@ class MonitorRingDoorbell(Monitor):
         super().__init__(name, config_options)
         if ring_doorbell is None:
             self.monitor_logger.critical("ring_doorbell library is not installed")
-        self.device_name = cast(
-            str, self.get_config_option(config_options, "device_name")
-        )
+        self.device_name = cast(str, self.get_config_option("device_name"))
         self.minimum_battery = cast(
             int,
-            self.get_config_option(
-                config_options, "minimum_battery", required_type="int", default=25
-            ),
+            self.get_config_option("minimum_battery", required_type="int", default=25),
         )
-        self.ring_username = cast(
-            str, self.get_config_option(config_options, "username")
-        )
-        self.ring_password = cast(
-            str, self.get_config_option(config_options, "password")
-        )
+        self.ring_username = cast(str, self.get_config_option("username"))
+        self.ring_password = cast(str, self.get_config_option("password"))
         self.cache_file = Path(
-            self.get_config_option(
-                config_options, "cache_file", default=".ring_token.cache"
-            )
+            self.get_config_option("cache_file", default=".ring_token.cache")
         )
         if self.cache_file.is_file():
             self.monitor_logger.info("Using token cache file for Ring")

--- a/simplemonitor/Monitors/service.py
+++ b/simplemonitor/Monitors/service.py
@@ -25,10 +25,8 @@ class MonitorSvc(Monitor):
     path = ""
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.path = cast(
-            str, Monitor.get_config_option(config_options, "path", required=True)
-        )
+        super().__init__(name, config_options)
+        self.path = cast(str, self.get_config_option("path", required=True))
         self.params = ("svok %s" % self.path).split(" ")
 
     def run_test(self) -> bool:
@@ -63,14 +61,10 @@ class MonitorService(Monitor):
     type = "service"
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.service_name = Monitor.get_config_option(
-            config_options, "service", required=True
-        )
-        self.want_state = Monitor.get_config_option(
-            config_options, "state", default="RUNNING"
-        )
-        self.host = Monitor.get_config_option(config_options, "host", default=".")
+        super().__init__(name, config_options)
+        self.service_name = self.get_config_option("service", required=True)
+        self.want_state = self.get_config_option("state", default="RUNNING")
+        self.host = self.get_config_option("host", default=".")
 
         if self.want_state not in ["RUNNING", "STOPPED"]:
             raise MonitorConfigurationError(
@@ -127,21 +121,13 @@ class MonitorRC(Monitor):
         """Initialise the class.
         Change script path to /etc/rc.d/ to monitor base system services. If the
         script path ends with /, the service name is appended."""
-        Monitor.__init__(self, name, config_options)
-        self.service_name = cast(
-            str, Monitor.get_config_option(config_options, "service", required=True)
-        )
+        super().__init__(name, config_options)
+        self.service_name = cast(str, self.get_config_option("service", required=True))
         self.script_path = cast(
-            str,
-            Monitor.get_config_option(
-                config_options, "path", default="/usr/local/etc/rc.d"
-            ),
+            str, self.get_config_option("path", default="/usr/local/etc/rc.d")
         )
         self.want_return_code = cast(
-            str,
-            Monitor.get_config_option(
-                config_options, "return_code", required_type="int", default=0
-            ),
+            str, self.get_config_option("return_code", required_type="int", default=0)
         )
         if self.script_path.endswith("/"):
             self.script_path = self.script_path + self.service_name
@@ -195,35 +181,28 @@ class MonitorSystemdUnit(Monitor):
     CACHE_LIFETIME = 1  # in seconds
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
+        super().__init__(name, config_options)
         if not pydbus:
             self.monitor_logger.critical(
                 "pydbus package is not available, cannot use MonitorSystemdUnit."
             )
             return
-        self.unit_name = cast(
-            str, Monitor.get_config_option(config_options, "name", required=True)
-        )
+        self.unit_name = cast(str, self.get_config_option("name", required=True))
         self.want_load_states = cast(
             List[str],
-            Monitor.get_config_option(
-                config_options, "load_states", required_type="[str]", default=["loaded"]
+            self.get_config_option(
+                "load_states", required_type="[str]", default=["loaded"]
             ),
         )
         self.want_active_states = cast(
             List[str],
-            Monitor.get_config_option(
-                config_options,
-                "active_states",
-                required_type="[str]",
-                default=["active", "reloading"],
+            self.get_config_option(
+                "active_states", required_type="[str]", default=["active", "reloading"]
             ),
         )
         self.want_sub_states = cast(
             List[str],
-            Monitor.get_config_option(
-                config_options, "sub_states", required_type="[str]", default=[]
-            ),
+            self.get_config_option("sub_states", required_type="[str]", default=[]),
         )
 
     @classmethod
@@ -304,13 +283,11 @@ class MonitorEximQueue(Monitor):
     path = "/usr/local/sbin"
 
     def __init__(self, name: str, config_options: dict) -> None:
-        Monitor.__init__(self, name, config_options)
-        self.max_length = Monitor.get_config_option(
-            config_options, "max_length", required_type="int", minimum=1
+        super().__init__(name, config_options)
+        self.max_length = self.get_config_option(
+            "max_length", required_type="int", minimum=1
         )
-        path = Monitor.get_config_option(
-            config_options, "path", default="/usr/local/sbin"
-        )
+        path = self.get_config_option("path", default="/usr/local/sbin")
         self.path = os.path.join(path, "exiqgrep")
 
     def run_test(self) -> bool:
@@ -357,11 +334,11 @@ class MonitorWindowsDHCPScope(Monitor):
     def __init__(self, name: str, config_options: dict) -> None:
         if not self.is_windows(True):
             raise RuntimeError("DHCPScope monitor requires a Windows platform.")
-        Monitor.__init__(self, name, config_options)
-        self.max_used = Monitor.get_config_option(
-            config_options, "max_used", required_type="int", minimum=1
+        super().__init__(name, config_options)
+        self.max_used = self.get_config_option(
+            "max_used", required_type="int", minimum=1
         )
-        self.scope = Monitor.get_config_option(config_options, "scope", required=True)
+        self.scope = self.get_config_option("scope", required=True)
 
     def run_test(self) -> bool:
         try:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -150,40 +150,23 @@ class TestMonitor(unittest.TestCase):
             "test_bool3": "true",
             "test_bool4": "0",
         }
+        m = Monitor("test", config_options)
+        self.assertEqual(m.get_config_option("test_string"), "a string")
+        self.assertEqual(m.get_config_option("test_int", required_type="int"), 3)
         self.assertEqual(
-            Monitor.get_config_option(config_options, "test_string"), "a string"
+            m.get_config_option("test_[int]", required_type="[int]"), [1, 2, 3]
         )
         self.assertEqual(
-            Monitor.get_config_option(config_options, "test_int", required_type="int"),
-            3,
-        )
-        self.assertEqual(
-            Monitor.get_config_option(
-                config_options, "test_[int]", required_type="[int]"
-            ),
-            [1, 2, 3],
-        )
-        self.assertEqual(
-            Monitor.get_config_option(
-                config_options, "test_[str]", required_type="[str]"
-            ),
-            ["a", "b", "c"],
+            m.get_config_option("test_[str]", required_type="[str]"), ["a", "b", "c"]
         )
         for bool_test in list(range(1, 4)):
             self.assertEqual(
-                Monitor.get_config_option(
-                    config_options,
-                    "test_bool{0}".format(bool_test),
-                    required_type="bool",
+                m.get_config_option(
+                    "test_bool{0}".format(bool_test), required_type="bool"
                 ),
                 True,
             )
-        self.assertEqual(
-            Monitor.get_config_option(
-                config_options, "test_bool4", required_type="bool"
-            ),
-            False,
-        )
+        self.assertEqual(m.get_config_option("test_bool4", required_type="bool"), False)
 
     def test_downtime(self):
         m = Monitor()


### PR DESCRIPTION
Use `super()`, and hold a copy of `config_options` in the `Monitor`, `Alerter` and `Logger` superclass, removing the need to pass it in every time.