### PR TITLE
Add failure_doc property for Monitors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+        exclude: tests/test_alerter.py
     -   id: flake8
 -   repo: https://github.com/psf/black
     rev: 19.10b0

--- a/docs/_includes/monitors.html
+++ b/docs/_includes/monitors.html
@@ -21,6 +21,7 @@ All monitor types share the following configuration options:
 |recovered_command| A command to execute once when this monitor succeeds the first time after being failed.|no| |
 |group|The group the monitor belongs to. Alerters will only fire for monitors which appear in their groups.|no|`default`|
 |notify|If the monitor should alert at all|no|1|
+|failure_doc|Information to include in alerts on failure (e.g. a URL to a runbook)|no| |
 {% for monitor in m %}
 <a name="{{monitor.name}}"></a>
 

--- a/simplemonitor/Alerters/alerter.py
+++ b/simplemonitor/Alerters/alerter.py
@@ -345,7 +345,13 @@ class Alerter:
                 Description: {desc}
                 """
                 if monitor.recover_info != "":
-                    message = message + "Recovery info: {}".format(monitor.recover_info)
+                    message = message + "Recovery info: {}\n".format(
+                        monitor.recover_info
+                    )
+                if monitor.failure_doc:
+                    message = message + "Documentation: {}\n".format(
+                        monitor.failure_doc
+                    )
             elif alert_type == AlertType.SUCCESS:
                 message = """
                 Monitor {monitor.name}{host} {alert_verb}!

--- a/simplemonitor/Monitors/monitor.py
+++ b/simplemonitor/Monitors/monitor.py
@@ -86,6 +86,9 @@ class Monitor:
         self.minimum_gap = self.get_config_option(
             "gap", required_type="int", minimum=0, default=0
         )
+        self.failure_doc = cast(
+            Optional[str], self.get_config_option("failure_doc", default=None)
+        )
 
         self.running_on = short_hostname()
         self._state = MonitorState.UNKNOWN

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -321,7 +321,9 @@ class TestMessageBuilding(unittest.TestCase):
                 alerter.Alerter.build_message(
                     alerter.AlertLength.ONELINE, alerter.AlertType.FAILURE, m
                 ),
-                "failure: test failed on babylon5 at 2020-03-10 09:00:00 (0+00:00:00): This monitor always fails.",
+                "failure: test failed on {hostname} at 2020-03-10 09:00:00 (0+00:00:00): This monitor always fails.".format(
+                    hostname=util.short_hostname()
+                ),
             )
 
     def test_oneline_format_success(self):
@@ -331,7 +333,10 @@ class TestMessageBuilding(unittest.TestCase):
                 m.run_test()
             m.last_result = "a " * 80
             desired = (
-                "success: winning succeeded on babylon5 at  (0+00:00:00): " + "a " * 80
+                "success: winning succeeded on {hostname} at  (0+00:00:00): ".format(
+                    hostname=util.short_hostname()
+                )
+                + "a " * 80
             )
             output = alerter.Alerter.build_message(
                 alerter.AlertLength.ONELINE, alerter.AlertType.SUCCESS, m
@@ -346,7 +351,9 @@ class TestMessageBuilding(unittest.TestCase):
                 alerter.Alerter.build_message(
                     alerter.AlertLength.SMS, alerter.AlertType.FAILURE, m
                 ),
-                "failure: test failed on babylon5 at 2020-03-10 09:00:00 (0+00:00:00): This monitor always fails.",
+                "failure: test failed on {hostname} at 2020-03-10 09:00:00 (0+00:00:00): This monitor always fails.".format(
+                    hostname=util.short_hostname()
+                ),
             )
 
     def test_sms_format_success(self):
@@ -359,7 +366,9 @@ class TestMessageBuilding(unittest.TestCase):
                 alerter.Alerter.build_message(
                     alerter.AlertLength.SMS, alerter.AlertType.SUCCESS, m
                 ),
-                "success: winning succeeded on babylon5 at (0+00:00:00): a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a...",
+                "success: winning succeeded on {hostname} at (0+00:00:00): a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a...".format(
+                    hostname=util.short_hostname()
+                ),
             )
 
     def test_full_format_failure(self):
@@ -372,12 +381,14 @@ class TestMessageBuilding(unittest.TestCase):
                 ),
                 textwrap.dedent(
                     """
-                    Monitor test on babylon5 failed!
+                    Monitor test on {hostname} failed!
                     Failed at: 2020-03-10 09:00:00 (down 0+00:00:00)
                     Virtual failure count: 1
                     Additional info: This monitor always fails.
                     Description: A monitor which always fails.
-                    """
+                    """.format(
+                        hostname=util.short_hostname()
+                    )
                 ),
             )
 
@@ -391,13 +402,15 @@ class TestMessageBuilding(unittest.TestCase):
                 ),
                 textwrap.dedent(
                     """
-                    Monitor test on babylon5 failed!
+                    Monitor test on {hostname} failed!
                     Failed at: 2020-03-10 09:00:00 (down 0+00:00:00)
                     Virtual failure count: 1
                     Additional info: This monitor always fails.
                     Description: A monitor which always fails.
                     Documentation: whoops
-                    """
+                    """.format(
+                        hostname=util.short_hostname()
+                    )
                 ),
             )
 
@@ -412,11 +425,13 @@ class TestMessageBuilding(unittest.TestCase):
                 ),
                 textwrap.dedent(
                     """
-                    Monitor winning on babylon5 succeeded!
-                    Recovered at:
-                    Additional info:
+                    Monitor winning on {hostname} succeeded!
+                    Recovered at: 
+                    Additional info: 
                     Description: (Monitor did not write an auto-biography.)
-                    """  # noqa: W291
+                    """.format(  # noqa: W291
+                        hostname=util.short_hostname()
+                    )
                 ),
             )
 

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -1,5 +1,6 @@
 # type: ignore
 import datetime
+import textwrap
 import unittest
 
 from freezegun import freeze_time
@@ -286,6 +287,138 @@ class TestAlerter(unittest.TestCase):
         with freeze_time("2020-03-10 10:30"):
             self.assertEqual(a.should_alert(m), alerter.AlertType.FAILURE)
             self.assertEqual(a._ooh_failures, [])
+
+
+class TestMessageBuilding(unittest.TestCase):
+    def test_notification_format_failure(self):
+        m = monitor.MonitorFail("test", {})
+        with freeze_time("2020-03-10 09:00"):
+            m.run_test()
+            self.assertEqual(
+                alerter.Alerter.build_message(
+                    alerter.AlertLength.NOTIFICATION, alerter.AlertType.FAILURE, m
+                ),
+                "Monitor test failed",
+            )
+
+    def test_notification_format_success(self):
+        m = monitor.MonitorNull("winning", {})
+        with freeze_time("2020-03-10 09:00"):
+            for _ in range(0, 6):
+                m.run_test()
+            self.assertEqual(
+                alerter.Alerter.build_message(
+                    alerter.AlertLength.NOTIFICATION, alerter.AlertType.SUCCESS, m
+                ),
+                "Monitor winning succeeded",
+            )
+
+    def test_oneline_format_failure(self):
+        m = monitor.MonitorFail("test", {})
+        with freeze_time("2020-03-10 09:00"):
+            m.run_test()
+            self.assertEqual(
+                alerter.Alerter.build_message(
+                    alerter.AlertLength.ONELINE, alerter.AlertType.FAILURE, m
+                ),
+                "failure: test failed on babylon5 at 2020-03-10 09:00:00 (0+00:00:00): This monitor always fails.",
+            )
+
+    def test_oneline_format_success(self):
+        m = monitor.MonitorNull("winning", {})
+        with freeze_time("2020-03-10 09:00"):
+            for _ in range(0, 6):
+                m.run_test()
+            m.last_result = "a " * 80
+            desired = (
+                "success: winning succeeded on babylon5 at  (0+00:00:00): " + "a " * 80
+            )
+            output = alerter.Alerter.build_message(
+                alerter.AlertLength.ONELINE, alerter.AlertType.SUCCESS, m
+            )
+            self.assertEqual(desired, output)
+
+    def test_sms_format_failure(self):
+        m = monitor.MonitorFail("test", {})
+        with freeze_time("2020-03-10 09:00"):
+            m.run_test()
+            self.assertEqual(
+                alerter.Alerter.build_message(
+                    alerter.AlertLength.SMS, alerter.AlertType.FAILURE, m
+                ),
+                "failure: test failed on babylon5 at 2020-03-10 09:00:00 (0+00:00:00): This monitor always fails.",
+            )
+
+    def test_sms_format_success(self):
+        m = monitor.MonitorNull("winning", {})
+        with freeze_time("2020-03-10 09:00"):
+            for _ in range(0, 6):
+                m.run_test()
+            m.last_result = "a " * 80
+            self.assertEqual(
+                alerter.Alerter.build_message(
+                    alerter.AlertLength.SMS, alerter.AlertType.SUCCESS, m
+                ),
+                "success: winning succeeded on babylon5 at (0+00:00:00): a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a...",
+            )
+
+    def test_full_format_failure(self):
+        m = monitor.MonitorFail("test", {})
+        with freeze_time("2020-03-10 09:00"):
+            m.run_test()
+            self.assertEqual(
+                alerter.Alerter.build_message(
+                    alerter.AlertLength.FULL, alerter.AlertType.FAILURE, m
+                ),
+                textwrap.dedent(
+                    """
+                    Monitor test on babylon5 failed!
+                    Failed at: 2020-03-10 09:00:00 (down 0+00:00:00)
+                    Virtual failure count: 1
+                    Additional info: This monitor always fails.
+                    Description: A monitor which always fails.
+                    """
+                ),
+            )
+
+    def test_full_format_failure_docs(self):
+        m = monitor.MonitorFail("test", {"failure_doc": "whoops"})
+        with freeze_time("2020-03-10 09:00"):
+            m.run_test()
+            self.assertEqual(
+                alerter.Alerter.build_message(
+                    alerter.AlertLength.FULL, alerter.AlertType.FAILURE, m
+                ),
+                textwrap.dedent(
+                    """
+                    Monitor test on babylon5 failed!
+                    Failed at: 2020-03-10 09:00:00 (down 0+00:00:00)
+                    Virtual failure count: 1
+                    Additional info: This monitor always fails.
+                    Description: A monitor which always fails.
+                    Documentation: whoops
+                    """
+                ),
+            )
+
+    def test_full_format_success(self):
+        m = monitor.MonitorNull("winning", {})
+        with freeze_time("2020-03-10 09:00"):
+            for _ in range(0, 6):
+                m.run_test()
+            self.assertEqual(
+                alerter.Alerter.build_message(
+                    alerter.AlertLength.FULL, alerter.AlertType.SUCCESS, m
+                ),
+                textwrap.dedent(
+                    """
+                    Monitor winning on babylon5 succeeded!
+                    Recovered at:
+                    Additional info:
+                    Description: (Monitor did not write an auto-biography.)
+                    """  # noqa: W291
+                ),
+            )
 
 
 class TestSNSAlerter(unittest.TestCase):


### PR DESCRIPTION
This is so e.g. a URL to a runbook can be included

Fixes #434 