### PR TITLE
Use native Python to ping

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,5 +30,6 @@ jobs:
         run: make black
       - name: flake8 tests
         run: make flake8
+        if: ${{ matrix.python-version == '3.8' }}
       - name: bandit
         run: make bandit

--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,8 @@ psutil = "*"
 pywin32 = {sys_platform = "== 'win32'"}
 pyarlo = "*"
 arrow = "*"
-"simplemonitor" = {editable = true, path = "."}
+simplemonitor = {editable = true,path = "."}
+ping3 = "*"
 
 [dev-packages]
 "flake8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d386106a758dfbe5cd11771c1db7e3b1d4ef8362d646385c225b28f400c0cbd1"
+            "sha256": "96c04471632a1430bc23f9301f4debdc03435609d7e92881ae28920e4fcf813a"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -151,6 +151,14 @@
             ],
             "index": "pypi",
             "version": "==1.5.0"
+        },
+        "ping3": {
+            "hashes": [
+                "sha256:afb7b37ad1f3c706e7d3b42a173c0cf6edd1780cf506566c97355145e986993e",
+                "sha256:d68b567b0516dadbb2b1e4834aabb5c5a955deda5c5d0b96ae5c9878d1a4378c"
+            ],
+            "index": "pypi",
+            "version": "==2.6.2"
         },
         "psutil": {
             "hashes": [
@@ -384,20 +392,13 @@
             "index": "pypi",
             "version": "==5.1"
         },
-        "entrypoints": {
-            "hashes": [
-                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
-                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
-            ],
-            "version": "==0.3"
-        },
         "flake8": {
             "hashes": [
-                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
-                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
+                "sha256:c09e7e4ea0d91fa36f7b8439ca158e592be56524f0b67c39ab0ea2b85ed8f9a4",
+                "sha256:f33c5320eaa459cdee6367016a4bf4ba2a9b81499ce56e6a32abbf0b8d3a2eb4"
             ],
             "index": "pypi",
-            "version": "==3.7.9"
+            "version": "==3.8.0a2"
         },
         "freezegun": {
             "hashes": [
@@ -478,17 +479,17 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:933bfe8d45355fbb35f9017d81fc51df8cb7ce58b82aca2568b870bf7bea1611",
+                "sha256:c1362bf675a7c0171fa5f795917c570c2e405a97e5dc473b51f3656075d73acc"
             ],
-            "version": "==2.5.0"
+            "version": "==2.6.0a1"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
-                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
+                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
-            "version": "==2.1.1"
+            "version": "==2.2.0"
         },
         "python-dateutil": {
             "hashes": [

--- a/docs/_data/monitors.yml
+++ b/docs/_data/monitors.yml
@@ -1,9 +1,17 @@
 - name: host
-  oneline: Pings a host (once per iteration) to see if it’s available. Multiplatform. See also the "ping" monitor.
+  oneline: Pings a host (once per iteration) to see if it’s available. Multiplatform, but can break on non-English ping output without additional config. See also the "ping" monitor.
   params:
       - name: host
         desc: The hostname to ping.
         required: 'yes'
+      - name: ping_regexp
+        desc: The regexp which matches a successful ping line. You may need to set this if your ping output is not in English
+        required: 'no'
+        default: auto
+      - name: time_regexp
+        desc: The regexp which matches the ping time in the output. Must set a match group named "ms". you may need to set this if your ping output is not in English.
+        required: 'no'
+        default: auto
 - name: service
   oneline: Checks a Windows service to make sure it’s running. Windows only.
   params:

--- a/docs/_data/monitors.yml
+++ b/docs/_data/monitors.yml
@@ -1,5 +1,5 @@
 - name: host
-  oneline: Pings a host (once per iteration) to see if it’s available. Multiplatform.
+  oneline: Pings a host (once per iteration) to see if it’s available. Multiplatform. See also the "ping" monitor.
   params:
       - name: host
         desc: The hostname to ping.
@@ -263,3 +263,13 @@
       desc: Limit matches to processes owned by this username
       required: 'no'
       default: blank (any user)
+- name: ping
+  oneline: Pings a host to make sure it's up. Uses a Python ping module instead of calling out to an external app, but needs to be run as root.
+  params:
+    - name: host
+      desc: The host/IP to ping.
+      required: 'yes'
+    - name: timeout
+      desc: The timeout for the ping in seconds
+      required: 'no'
+      default: 5

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "boto3",
         "colorlog",
         "paho-mqtt",
+        "ping3",
         "psutil",
         "pyOpenSSL",
         "requests",

--- a/simplemonitor/Monitors/network.py
+++ b/simplemonitor/Monitors/network.py
@@ -236,6 +236,12 @@ class MonitorHost(Monitor):
             self.time_regexp = r"min/avg/max/stddev = [\d.]+/(?P<ms>[\d.]+)/"
         else:
             RuntimeError("Don't know how to run ping on this platform, help!")
+        self.ping_regexp = self.get_config_option(
+            "ping_regexp", required=False, default=self.ping_regexp
+        )
+        self.time_regexp = self.get_config_option(
+            "time_regexp", required=False, default=self.ping_regexp
+        )
 
         self.host = self.get_config_option("host", required=True)
 
@@ -256,10 +262,10 @@ class MonitorHost(Monitor):
                 if matches:
                     success = True
                 else:
-                    assert isinstance(self.r2, Pattern)
-                    matches = self.r2.search(line)
-                    if matches:
-                        pingtime = float(matches.group("ms"))
+                    if isinstance(self.r2, Pattern):
+                        matches = self.r2.search(line)
+                        if matches:
+                            pingtime = float(matches.group("ms"))
         except Exception as e:
             return self.record_fail(str(e))
         if success:

--- a/simplemonitor/Monitors/network.py
+++ b/simplemonitor/Monitors/network.py
@@ -375,8 +375,8 @@ class MonitorPing(Monitor):
         if "ping3" not in sys.modules:
             return self.record_fail("Missing required ping3 module")
         try:
-            response_time = ping3.ping(self.host, timeout=self.timeout)
-            return self.record_success("Ping time {}ms".format(response_time))
+            response_time = ping3.ping(self.host, timeout=self.timeout, unit="ms")
+            return self.record_success("Ping time {:0.3f}ms".format(response_time))
         except ping3.errors.PingError as excepton:
             return self.record_fail(str(excepton))
         except PermissionError:

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -153,9 +153,12 @@ class SimpleMonitor:
                         not_run = True
                         self.monitors[monitor].record_skip(None)
                         module_logger.info("Not run: %s", monitor)
-                except Exception:
+                except Exception as exeception:
                     module_logger.exception(
                         "Monitor %s threw exception during run_test()", monitor
+                    )
+                    self.monitors[monitor].record_fail(
+                        "Unhandled exception: {}".format(exeception)
                     )
                 if self.monitors[monitor].error_count > 0:
                     if self.monitors[monitor].virtual_fail_count() == 0:

--- a/tests/monitors.ini
+++ b/tests/monitors.ini
@@ -333,11 +333,3 @@ min_count=60000
 type=process
 process_name=python3
 username=unlikely-username
-
-[new-ping]
-type=ping
-host=127.0.0.1
-
-[new-ping-fail]
-type=ping
-host=fake.jamesoff.net

--- a/tests/monitors.ini
+++ b/tests/monitors.ini
@@ -333,3 +333,11 @@ min_count=60000
 type=process
 process_name=python3
 username=unlikely-username
+
+[new-ping]
+type=ping
+host=127.0.0.1
+
+[new-ping-fail]
+type=ping
+host=fake.jamesoff.net


### PR DESCRIPTION
Use the `ping3` package to perform ping directly in Python.

Pros: no more having to execute ping(8), no more having to figure out the options for it from platform, and no more having to parse its output which breaks based on locale.

Cons: The new monitor needs root to work; however quite a few other features can make use of being root so this is likely not a problem.

The original monitor lives on as before as `host` to avoid breaking anyone's existing config, and also gains config options to customise the regexes used to match the output, so it can be adjusted for a different language if needed. The new monitor is type `ping`.

Fixes #102
Fixes #10