### PR TITLE
Refactor all logic into SimpleMonitor class

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,7 @@
 
 SimpleMonitor is a Python script which monitors hosts and network connectivity. It is designed to be quick and easy to set up and lacks complex features that can make things like Nagios, OpenNMS and Zenoss overkill for a small business or home network. Remote monitor instances can send their results back to a central location.
 
+Requires Python >= 3.6.2.
+
 Documentation is here:
 http://jamesoff.github.io/simplemonitor/

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "Topic :: System :: Monitoring",
         "Typing :: Typed",
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6.2",
     entry_points={
         "console_scripts": [
             "simplemonitor=simplemonitor.monitor:main",

--- a/simplemonitor/monitor.py
+++ b/simplemonitor/monitor.py
@@ -1,273 +1,26 @@
 # coding=utf-8
-"""A (fairly) simple host/service monitor.
-
-isort:skip_file
-"""
+"""A (fairly) simple host/service monitor. """
 
 
-import logging
-import os
-import signal
-import sys
-import time
 import argparse
-from socket import gethostname
-from typing import Any, Optional
-from configparser import Error as ConfigError
+import logging
+import sys
 
-
-import simplemonitor.Alerters as Alerters  # noqa: F401
-import simplemonitor.Loggers as Loggers  # noqa: F401
-import simplemonitor.Monitors as Monitors  # noqa: F401
+import simplemonitor.Alerters.alerter as alerter
 import simplemonitor.Loggers.logger as logger
 import simplemonitor.Monitors.monitor as monitor
-import simplemonitor.Alerters.alerter as alerter
-from .simplemonitor import SimpleMonitor
 
-from .util import get_config_dict
-from .util.envconfig import EnvironmentAwareConfigParser
+from .simplemonitor import SimpleMonitor
+from .version import VERSION
 
 try:
     import colorlog
 except ImportError:
     pass
 
-from .version import VERSION
 
 main_logger = logging.getLogger("simplemonitor")
 need_hup = False
-hup_timestamp = None
-
-
-def setup_signals() -> None:
-    """Set up the SIGHUP handler."""
-    _message = (
-        "Unable to trap SIGHUP... maybe it doesn't exist on this platform. "
-        "Set 'hup_file' in config and touch that file to trigger a config reload."
-    )
-    try:
-        signal.signal(signal.SIGHUP, handle_sighup)
-    except ValueError:  # pragma: no cover
-        main_logger.warning(_message)
-    except AttributeError:  # pragma: no cover
-        main_logger.warning(_message)
-
-
-def handle_sighup(*_: Any) -> None:
-    """Receive SIGHUP and process it."""
-    global need_hup
-    main_logger.warning("Received SIGHUP")
-    need_hup = True
-
-
-def check_hup_file(path: Optional[str]) -> bool:
-    """Check a file's timestamp, and if it's newer than last time, treat it
-    the same as receiving SIGHUP so that a reload is triggered. This allows
-    config reloading on platforms which don't support the signal (i.e.
-    Windows)"""
-    if path is None:
-        return False
-    try:
-        statinfo = os.stat(path)
-    except IOError:
-        main_logger.debug("Could not call stat() on path %s for file-based HUP", path)
-        return False
-    global hup_timestamp
-    modification_time = statinfo.st_mtime
-    if hup_timestamp is None:
-        hup_timestamp = modification_time
-        return True
-    if modification_time > hup_timestamp:
-        hup_timestamp = modification_time
-        return True
-    return False
-
-
-def load_everything(
-    m: SimpleMonitor, config: EnvironmentAwareConfigParser
-) -> SimpleMonitor:
-    """Load monitors, alerters and loggers into a SimpleMonitor object."""
-    monitors_file = config.get("monitor", "monitors", fallback="monitors.ini")
-    m = load_monitors(m, monitors_file)
-    m = load_loggers(m, config)
-    m = load_alerters(m, config)
-    if not m.verify_dependencies():
-        sys.exit(1)
-    return m
-
-
-def load_config(config_file: str) -> EnvironmentAwareConfigParser:
-    """Load the main configuration and return a config object."""
-    config = EnvironmentAwareConfigParser()
-    if not os.path.exists(config_file):
-        main_logger.critical('Configuration file "%s" does not exist!', config_file)
-        sys.exit(1)
-    try:
-        config.read(config_file)
-    except ConfigError:
-        main_logger.exception("Unable to read configuration file")
-        sys.exit(1)
-    return config
-
-
-def load_monitors(m: SimpleMonitor, filename: str) -> SimpleMonitor:
-    """Load all the monitors from the config file and return a populated SimpleMonitor."""
-    config = EnvironmentAwareConfigParser()
-    config.read(filename)
-    monitors = config.sections()
-    if "defaults" in monitors:
-        default_config = get_config_dict(config, "defaults")
-        monitors.remove("defaults")
-    else:
-        default_config = {}
-
-    myhostname = gethostname().lower()
-
-    main_logger.info("=== Loading monitors")
-    for this_monitor in monitors:
-        if config.has_option(this_monitor, "runon"):
-            if myhostname != config.get(this_monitor, "runon").lower():
-                main_logger.warning(
-                    "Ignoring monitor %s because it's only for host %s",
-                    this_monitor,
-                    config.get(this_monitor, "runon"),
-                )
-                continue
-        monitor_type = config.get(this_monitor, "type")
-        new_monitor = None
-        config_options = default_config.copy()
-        config_options.update(get_config_dict(config, this_monitor))
-        if m.has_monitor(this_monitor):
-            if m.monitors[this_monitor].monitor_type == config_options["type"]:
-                main_logger.info("Updating configuration for monitor %s", this_monitor)
-                m.update_monitor_config(this_monitor, config_options)
-            else:
-                main_logger.error(
-                    "Cannot update monitor %s from type %s to type %s. "
-                    "Keeping original config for this monitor.",
-                    this_monitor,
-                    m.monitors[this_monitor].monitor_type,
-                    config_options["type"],
-                )
-            continue
-
-        try:
-            cls = monitor.get_class(monitor_type)
-        except KeyError:
-            main_logger.error(
-                "Unknown monitor type %s; valid types are: %s",
-                monitor_type,
-                ", ".join(monitor.all_types()),
-            )
-            continue
-        new_monitor = cls(this_monitor, config_options)
-        # new_monitor.set_mon_refs(m)
-
-        main_logger.info(
-            "Adding %s monitor %s: %s", monitor_type, this_monitor, new_monitor
-        )
-        m.add_monitor(this_monitor, new_monitor)
-
-    for i in list(m.monitors.keys()):
-        m.monitors[i].set_mon_refs(m.monitors)
-        m.monitors[i].post_config_setup()
-    m.prune_monitors(monitors)
-    main_logger.info("--- Loaded %d monitors", m.count_monitors())
-    return m
-
-
-def load_loggers(
-    m: SimpleMonitor, config: EnvironmentAwareConfigParser
-) -> SimpleMonitor:
-    """Load the loggers listed in the config object."""
-
-    if config.has_option("reporting", "loggers"):
-        loggers = config.get("reporting", "loggers").split(",")
-    else:
-        loggers = []
-
-    main_logger.info("=== Loading loggers")
-    for config_logger in loggers:
-        logger_type = config.get(config_logger, "type")
-        config_options = get_config_dict(config, config_logger)
-        config_options["_name"] = config_logger
-        if m.has_logger(config_logger):
-            if m.loggers[config_logger].logger_type == config_options["type"]:
-                main_logger.info("Updating configuration for logger %s", config_logger)
-                m.update_logger_config(config_logger, config_options)
-            else:
-                main_logger.error(
-                    "Cannot update logger %s from type %s to type %s. "
-                    "Keeping original config for this logger.",
-                    config_logger,
-                    m.loggers[config_logger].logger_type,
-                    config_options["type"],
-                )
-            continue
-        try:
-            logger_cls = logger.get_class(logger_type)
-        except KeyError:
-            main_logger.error(
-                "Unknown logger type %s; valid types are: %s",
-                logger_type,
-                ", ".join(logger.all_types()),
-            )
-            continue
-        new_logger = logger_cls(config_options)  # type: logger.Logger
-        new_logger.set_global_info({"interval": config.getint("monitor", "interval")})
-        main_logger.info(
-            "Adding %s logger %s: %s", logger_type, config_logger, new_logger
-        )
-        m.add_logger(config_logger, new_logger)
-        del new_logger
-    m.prune_loggers(loggers)
-    main_logger.info("--- Loaded %d loggers", len(m.loggers))
-    return m
-
-
-def load_alerters(
-    m: SimpleMonitor, config: EnvironmentAwareConfigParser
-) -> SimpleMonitor:
-    """Load the alerters listed in the config object."""
-    if config.has_option("reporting", "alerters"):
-        alerters = config.get("reporting", "alerters").split(",")
-    else:
-        alerters = []
-
-    main_logger.info("=== Loading alerters")
-    for this_alerter in alerters:
-        alerter_type = config.get(this_alerter, "type")
-        config_options = get_config_dict(config, this_alerter)
-        if m.has_alerter(this_alerter):
-            if m.alerters[this_alerter].alerter_type == config_options["type"]:
-                main_logger.info("Updating configuration for alerter %s", this_alerter)
-                m.update_alerter_config(this_alerter, config_options)
-            else:
-                main_logger.error(
-                    "Cannot update alerter %s from type %s to type %s. "
-                    "Keeping original config for this alerter.",
-                    this_alerter,
-                    m.alerters[this_alerter].alerter_type,
-                    config_options["type"],
-                )
-            continue
-        try:
-            alerter_cls = alerter.get_class(alerter_type)
-        except KeyError:
-            main_logger.error(
-                "Unknown alerter type %s; valid types are: %s",
-                alerter_type,
-                ", ".join(alerter.all_types()),
-            )
-            continue
-        new_alerter = alerter_cls(config_options)
-        main_logger.info("Adding %s alerter %s", alerter_type, this_alerter)
-        new_alerter.name = this_alerter
-        m.add_alerter(this_alerter, new_alerter)
-        del new_alerter
-    m.prune_alerters(alerters)
-    main_logger.info("--- Loaded %d alerters", len(m.alerters))
-    return m
 
 
 def main() -> None:
@@ -444,56 +197,21 @@ def main() -> None:
         main_logger.info("=== SimpleMonitor v%s", VERSION)
         main_logger.info("Loading main config from %s", options.config)
 
-    config = load_config(options.config)
-
-    try:
-        interval = config.getint("monitor", "interval")
-    except ConfigError:
-        main_logger.critical(
-            'Missing [monitor] section from config file, or missing the "interval" setting in it'
-        )
-        sys.exit(1)
-
-    pidfile = config.get("monitor", "pidfile", fallback=None)
-
-    if options.pidfile:
-        pidfile = options.pidfile
-
-    if pidfile:
-        my_pid = os.getpid()
-        try:
-            with open(pidfile, "w") as file_handle:
-                file_handle.write("%d\n" % my_pid)
-        except IOError:
-            main_logger.error("Couldn't write to pidfile!")
-            pidfile = None
-
-    monitors_file = config.get("monitor", "monitors", fallback="monitors.ini")
-    main_logger.info("Loading monitor config from %s", monitors_file)
-
-    try:
-        allow_pickle = config.getboolean("monitor", "allow_pickle", fallback=True)
-    except ValueError:
-        main_logger.critical('allow_pickle should be "true" or "false".')
-        sys.exit(1)
-
-    m = SimpleMonitor(allow_pickle=allow_pickle)
-    m = load_everything(m, config)
-
-    count = m.count_monitors()
-    if count == 0:
-        main_logger.critical("No monitors loaded :(")
-        sys.exit(2)
-
-    enable_remote = False
-    if config.get("monitor", "remote", fallback="0") == "1":
-        if not options.no_network:
-            enable_remote = True
-            remote_port = int(config.get("monitor", "remote_port"))
-    key = config.get("monitor", "key", fallback=None)
-
-    if not m.verify_alerting():
-        main_logger.critical("No alerters defined and no remote logger found")
+    # if pidfile:
+    #     my_pid = os.getpid()
+    #     try:
+    #         with open(pidfile, "w") as file_handle:
+    #             file_handle.write("%d\n" % my_pid)
+    #     except IOError:
+    #         main_logger.error("Couldn't write to pidfile!")
+    #         pidfile = None
+    m = SimpleMonitor(
+        config_file=options.config,
+        no_network=options.no_network,
+        max_loops=options.loops,
+        heartbeat=not options.no_heartbeat,
+        one_shot=options.one_shot,
+    )
 
     if options.test:
         main_logger.warning("Config test complete. Exiting.")
@@ -505,111 +223,9 @@ def main() -> None:
             "and with to fail. Will exit zero or non-zero accordingly."
         )
 
-    if enable_remote:
-        if not options.quiet:
-            if not allow_pickle:
-                allowing_pickle = "not "
-            else:
-                allowing_pickle = ""
-            main_logger.info(
-                "Starting remote listener thread (%sallowing pickle data)",
-                allowing_pickle,
-            )
-        remote_listening_thread = Loggers.Listener(
-            m,
-            remote_port,
-            key,
-            allow_pickle=allow_pickle,
-            bind_host=config.get("monitor", "bind_host", fallback=""),
-        )
-        remote_listening_thread.daemon = True
-        remote_listening_thread.start()
+    m.run()
 
-    if not options.quiet:
-        main_logger.info(
-            "=== Starting... (loop runs every %ds) Hit ^C to stop", interval
-        )
-    loop = True
-    heartbeat = 0
-
-    loops = int(options.loops)
-    setup_signals()
-    hup_file = config.get("monitor", "hup_file", fallback=None)
-    if hup_file:
-        main_logger.info(
-            "Watching modification time of %s; increase it to trigger a config reload",
-            hup_file,
-        )
-        check_hup_file(hup_file)
-
-    global need_hup
-    while loop:
-        try:
-            if loops > 0:
-                loops -= 1
-                if loops == 0:
-                    main_logger.warning(
-                        "Ran out of loop counter, will stop after this one"
-                    )
-                    loop = False
-            if need_hup or check_hup_file(hup_file):
-                try:
-                    main_logger.warning("Reloading configuration")
-                    config = load_config(options.config)
-                    interval = config.getint("monitor", "interval")
-                    m = load_everything(m, config)
-                    m.hup_loggers()
-                    need_hup = False
-                except Exception:
-                    main_logger.exception("Error while reloading configuration")
-                    sys.exit(1)
-            m.run_loop()
-
-            if (
-                options.loglevel in ["error", "critical", "warn"]
-                and not options.no_heartbeat
-            ):
-                heartbeat += 1
-                if heartbeat == 2:
-                    sys.stdout.write(".")
-                    sys.stdout.flush()
-                    heartbeat = 0
-        except KeyboardInterrupt:
-            main_logger.info("Received ^C")
-            loop = False
-        except Exception:
-            main_logger.exception("Caught unhandled exception during main loop")
-        if loop and enable_remote:
-            if not remote_listening_thread.isAlive():
-                main_logger.error("Listener thread died :(")
-                remote_listening_thread = Loggers.Listener(
-                    m, remote_port, key, allow_pickle=allow_pickle
-                )
-                remote_listening_thread.start()
-
-        if options.one_shot:
-            break
-
-        try:
-            if loop:
-                time.sleep(interval)
-        except Exception:
-            main_logger.info("Quitting")
-            loop = False
-
-    if enable_remote:
-        remote_listening_thread.running = False
-        main_logger.info("Waiting for listener thread to exit")
-        remote_listening_thread.join(0)
-
-    if pidfile:
-        try:
-            os.unlink(pidfile)
-        except Exception:
-            main_logger.error("Couldn't remove pidfile!")
-
-    if not options.quiet:
-        main_logger.info("Finished.")
+    main_logger.info("Finished.")
 
     if options.one_shot:  # pragma: no cover
         ok = True

--- a/simplemonitor/monitor.py
+++ b/simplemonitor/monitor.py
@@ -6,10 +6,6 @@ import argparse
 import logging
 import sys
 
-import simplemonitor.Alerters.alerter as alerter
-import simplemonitor.Loggers.logger as logger
-import simplemonitor.Monitors.monitor as monitor
-
 from .simplemonitor import SimpleMonitor
 from .version import VERSION
 
@@ -20,7 +16,6 @@ except ImportError:
 
 
 main_logger = logging.getLogger("simplemonitor")
-need_hup = False
 
 
 def main() -> None:
@@ -143,6 +138,9 @@ def main() -> None:
 
     if options.dump_resources:
         import pprint
+        import simplemonitor.Alerters.alerter as alerter
+        import simplemonitor.Loggers.logger as logger
+        import simplemonitor.Monitors.monitor as monitor
 
         print("Monitors:")
         pprint.pprint(sorted(monitor.all_types()), compact=True)

--- a/simplemonitor/monitor.py
+++ b/simplemonitor/monitor.py
@@ -195,14 +195,6 @@ def main() -> None:
         main_logger.info("=== SimpleMonitor v%s", VERSION)
         main_logger.info("Loading main config from %s", options.config)
 
-    # if pidfile:
-    #     my_pid = os.getpid()
-    #     try:
-    #         with open(pidfile, "w") as file_handle:
-    #             file_handle.write("%d\n" % my_pid)
-    #     except IOError:
-    #         main_logger.error("Couldn't write to pidfile!")
-    #         pidfile = None
     m = SimpleMonitor(
         config_file=options.config,
         no_network=options.no_network,

--- a/tests/monitor-badinterval.ini
+++ b/tests/monitor-badinterval.ini
@@ -1,0 +1,2 @@
+[monitor]
+interval=moo

--- a/tests/monitor-empty.ini
+++ b/tests/monitor-empty.ini
@@ -1,0 +1,3 @@
+[monitor]
+monitors=tests/monitors-empty.ini
+interval=60

--- a/tests/monitor-nointerval.ini
+++ b/tests/monitor-nointerval.ini
@@ -1,0 +1,2 @@
+[monitor]
+# oops

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -4,6 +4,7 @@ import socket
 import tempfile
 import time
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from freezegun import freeze_time
@@ -53,14 +54,14 @@ class TestLogger(unittest.TestCase):
     def test_groups(self):
         with patch.object(logger.Logger, "save_result2") as mock_method:
             this_logger = logger.Logger({"groups": "nondefault"})
-            s = SimpleMonitor()
+            s = SimpleMonitor(Path("tests/monitor-empty.ini"))
             s.add_monitor("test", MonitorNull())
             s.log_result(this_logger)
         mock_method.assert_not_called()
 
         with patch.object(logger.Logger, "save_result2") as mock_method:
             this_logger = logger.Logger({"groups": "nondefault"})
-            s = SimpleMonitor()
+            s = SimpleMonitor(Path("tests/monitor-empty.ini"))
             s.add_monitor("test", MonitorNull("unnamed", {"group": "nondefault"}))
             s.log_result(this_logger)
         mock_method.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,6 +44,20 @@ class TestMonitor(unittest.TestCase):
         os.unlink(temp_file_name)
 
 
+class TestPidFile(unittest.TestCase):
+    def test_pidfile(self):
+        s = simplemonitor.SimpleMonitor("tests/monitor-empty.ini")
+        s.pidfile = "__pid_test"
+        try:
+            os.unlink(s.pidfile)
+        except IOError:
+            pass
+        s._create_pid_file()
+        self.assertTrue(os.path.exists(s.pidfile))
+        s._remove_pid_file()
+        self.assertFalse(os.path.exists(s.pidfile))
+
+
 class TestSanity(unittest.TestCase):
     def test_config_has_alerting(self):
         m = simplemonitor.SimpleMonitor("tests/monitor-empty.ini")


### PR DESCRIPTION
This leaves monitor.py responsible just for CLI bits, no more ugly passing a SimpleMonitor object around to configure it!

Also updated README and setup.py with correct Python requirements.
Closes #480 