### PR TITLE
Add times_tz option to Alerters

### DIFF
--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -50,6 +50,7 @@ All alerters accept time period configuration. By default, an alerter is active 
 | day | Which days an alerter can operate on. This is a comma-separated list of integers. 0 is Monday and 6 is Sunday. | no | (all days)|
 | times_type | Set to one of always, only, or not. “Only” means that the limits define the period that an alerter can operate. “Not” means that the limits define the period during which it will not operate. | no | always |
 | time_lower and time_upper| If *times_type* is only or not, these two settings define the time limits. time_lower must always be the lower time. The time format is hh:mm using 24-hour clock. Both are required if times_type is anything other than always. | when *times_type* is not `always` | |
+| times_tz | the timezone you want time_lower and time_upper interpreted as | no | local |
 | delay | If any kind of time/day restriction applies, the alerter will notify you of any monitors that failed while they were unable to alert you and are still failed. If a monitor fails and recovers during the restricted period, no catch-up alert is generated. Set to 1 to enable. | no | 0 |
 
 Here’s a quick example of setting time periods (some other configuration values omitted):

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -196,16 +196,16 @@ class TestAlerter(unittest.TestCase):
         a = alerter.Alerter(
             {
                 "times_type": "only",
-                "time_lower": "14:00",
-                "time_upper": "15:00",
+                "time_lower": "15:00",
+                "time_upper": "16:00",
                 "times_tz": "+05:00",
             }
         )
-        with freeze_time("09:00", tz_offset=-self.utcoffset):
+        with freeze_time("09:00"):
             self.assertFalse(a._allowed_time())
-        with freeze_time("10:30", tz_offset=-self.utcoffset):
+        with freeze_time("10:30"):
             self.assertTrue(a._allowed_time())
-        with freeze_time("12:00", tz_offset=-self.utcoffset):
+        with freeze_time("12:00"):
             self.assertFalse(a._allowed_time())
 
     def test_allowed_not(self):
@@ -223,16 +223,16 @@ class TestAlerter(unittest.TestCase):
         a = alerter.Alerter(
             {
                 "times_type": "not",
-                "time_lower": "14:00",
-                "time_upper": "15:00",
+                "time_lower": "15:00",
+                "time_upper": "16:00",
                 "times_tz": "+05:00",
             }
         )
-        with freeze_time("09:00", tz_offset=-self.utcoffset):
+        with freeze_time("09:00"):
             self.assertTrue(a._allowed_time())
-        with freeze_time("10:30", tz_offset=-self.utcoffset):
+        with freeze_time("10:30"):
             self.assertFalse(a._allowed_time())
-        with freeze_time("12:00", tz_offset=-self.utcoffset):
+        with freeze_time("12:00"):
             self.assertTrue(a._allowed_time())
 
     def test_should_not_alert_ooh(self):


### PR DESCRIPTION
Allows the timezone for the time_upper and time_lower values to be
specified, rather than using local time.

Local time is the default if not specified, to avoid breaking anyone's
existing configuration.

Closes #527 