### PR TITLE
Fix groups for remote monitors; add _all wildcard

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -28,6 +28,7 @@ jobs:
         run: pipenv --bare install --dev
       - name: check code style with black
         run: make black
+        if: ${{ matrix.python-version == '3.8' }}  # broken in 3.6 currently
       - name: flake8 tests
         run: make flake8
         if: ${{ matrix.python-version == '3.8' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         exclude: tests/test_alerter.py
     -   id: flake8
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black
 -   repo: https://github.com/asottile/seed-isort-config

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ env-test:
 	env TEST_VALUE=myenv pipenv run coverage run --append monitor.py -t -f tests/monitor-env.ini
 
 unit-test:
-	pipenv run coverage run --append pytest tests
+	pipenv run coverage run --append -m pytest tests
 
 network-test:
 	pipenv run tests/test-network.sh

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ env-test:
 	env TEST_VALUE=myenv pipenv run coverage run --append monitor.py -t -f tests/monitor-env.ini
 
 unit-test:
-	pipenv run coverage run --append -m pytest tests
+	pipenv run coverage run --append -m unittest discover -s tests
 
 network-test:
 	pipenv run tests/test-network.sh

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ env-test:
 	env TEST_VALUE=myenv pipenv run coverage run --append monitor.py -t -f tests/monitor-env.ini
 
 unit-test:
-	pipenv run coverage run --append -m unittest discover -s tests
+	pipenv run coverage run --append pytest tests
 
 network-test:
 	pipenv run tests/test-network.sh

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ black = "*"
 mypy = "*"
 bandit = "*"
 freezegun = "*"
+pytest = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d9d62cc1e1d168884ec46950a48be3d3c68ef45008ae4d42139130b8f191f5d3"
+            "sha256": "76225f120d3297633ffd29c0b73040778181b1d56bac725aa3534f22e752ce6e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,25 +16,25 @@
     "default": {
         "arrow": {
             "hashes": [
-                "sha256:271b8e05174d48e50324ed0dc5d74796c839c7e579a4f21cf1a7394665f9e94f",
-                "sha256:edc31dc051db12c95da9bac0271cd1027b8e36912daf6d4580af53b23e62721a"
+                "sha256:92aac856ea5175c804f7ccb96aca4d714d936f1c867ba59d747a8096ec30e90a",
+                "sha256:98184d8dd3e5d30b96c2df4596526f7de679ccb467f358b82b0f686436f3a6b8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.15.8"
+            "version": "==0.16.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:9a3c6b6f93d381f1d7a06ec0f50a9ad3d7b81509443f80ba222eb66befa8976a",
-                "sha256:ec3a7662e318455727b4b36f4a57ba473a90b6526cebf1fc10e847182f1fd917"
+                "sha256:79e95f428c485ea817969a78e77a311d2ec4d82e0955639d6126189c990ddad3",
+                "sha256:d8ca27ee13deeb1a9e79f2fe5f923effa60947ed49bbdfbc2a9f5790aef64217"
             ],
-            "version": "==1.14.28"
+            "version": "==1.14.60"
         },
         "botocore": {
             "hashes": [
-                "sha256:71d45ae51c4c1a7ae485836016170a817d8d53292d940d04d72e49e473b98127",
-                "sha256:e855254817e289bb9a5fa3c143920c21ea8aeb424f1d4eed1e6c32d84dfd277d"
+                "sha256:193f193a66ac79106725e14dd73e28ed36bcec99b37156538a2202d061056a58",
+                "sha256:e55a4fc652537f5ccb2362133f3928ebeafb04ee9fe15ea11c2df80ba4ef8a12"
             ],
-            "version": "==1.17.28"
+            "version": "==1.17.60"
         },
         "certifi": {
             "hashes": [
@@ -45,36 +45,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:267adcf6e68d77ba154334a3e4fc921b8e63cbb38ca00d33d40655d4228502bc",
-                "sha256:26f33e8f6a70c255767e3c3f957ccafc7f1f706b966e110b855bfe944511f1f9",
-                "sha256:3cd2c044517f38d1b577f05927fb9729d3396f1d44d0c659a445599e79519792",
-                "sha256:4a03416915b82b81af5502459a8a9dd62a3c299b295dcdf470877cb948d655f2",
-                "sha256:4ce1e995aeecf7cc32380bc11598bfdfa017d592259d5da00fc7ded11e61d022",
-                "sha256:4f53e4128c81ca3212ff4cf097c797ab44646a40b42ec02a891155cd7a2ba4d8",
-                "sha256:4fa72a52a906425416f41738728268072d5acfd48cbe7796af07a923236bcf96",
-                "sha256:66dd45eb9530e3dde8f7c009f84568bc7cac489b93d04ac86e3111fb46e470c2",
-                "sha256:6923d077d9ae9e8bacbdb1c07ae78405a9306c8fd1af13bfa06ca891095eb995",
-                "sha256:833401b15de1bb92791d7b6fb353d4af60dc688eaa521bd97203dcd2d124a7c1",
-                "sha256:8416ed88ddc057bab0526d4e4e9f3660f614ac2394b5e019a628cdfff3733849",
-                "sha256:892daa86384994fdf4856cb43c93f40cbe80f7f95bb5da94971b39c7f54b3a9c",
-                "sha256:98be759efdb5e5fa161e46d404f4e0ce388e72fbf7d9baf010aff16689e22abe",
-                "sha256:a6d28e7f14ecf3b2ad67c4f106841218c8ab12a0683b1528534a6c87d2307af3",
-                "sha256:b1d6ebc891607e71fd9da71688fcf332a6630b7f5b7f5549e6e631821c0e5d90",
-                "sha256:b2a2b0d276a136146e012154baefaea2758ef1f56ae9f4e01c612b0831e0bd2f",
-                "sha256:b87dfa9f10a470eee7f24234a37d1d5f51e5f5fa9eeffda7c282e2b8f5162eb1",
-                "sha256:bac0d6f7728a9cc3c1e06d4fcbac12aaa70e9379b3025b27ec1226f0e2d404cf",
-                "sha256:c991112622baee0ae4d55c008380c32ecfd0ad417bcd0417ba432e6ba7328caa",
-                "sha256:cda422d54ee7905bfc53ee6915ab68fe7b230cacf581110df4272ee10462aadc",
-                "sha256:d3148b6ba3923c5850ea197a91a42683f946dba7e8eb82dfa211ab7e708de939",
-                "sha256:d6033b4ffa34ef70f0b8086fd4c3df4bf801fee485a8a7d4519399818351aa8e",
-                "sha256:ddff0b2bd7edcc8c82d1adde6dbbf5e60d57ce985402541cd2985c27f7bec2a0",
-                "sha256:e23cb7f1d8e0f93addf0cae3c5b6f00324cccb4a7949ee558d7b6ca973ab8ae9",
-                "sha256:effd2ba52cee4ceff1a77f20d2a9f9bf8d50353c854a282b8760ac15b9833168",
-                "sha256:f90c2267101010de42f7273c94a1f026e56cbc043f9330acd8a80e64300aba33",
-                "sha256:f960375e9823ae6a07072ff7f8a85954e5a6434f97869f50d0e41649a1c8144f",
-                "sha256:fcf32bf76dc25e30ed793145a57426064520890d7c02866eb93d3e4abe516948"
+                "sha256:0da50dcbccd7cb7e6c741ab7912b2eff48e85af217d72b57f80ebc616257125e",
+                "sha256:12a453e03124069b6896107ee133ae3ab04c624bb10683e1ed1c1663df17c13c",
+                "sha256:15419020b0e812b40d96ec9d369b2bc8109cc3295eac6e013d3261343580cc7e",
+                "sha256:15a5f59a4808f82d8ec7364cbace851df591c2d43bc76bcbe5c4543a7ddd1bf1",
+                "sha256:23e44937d7695c27c66a54d793dd4b45889a81b35c0751ba91040fe825ec59c4",
+                "sha256:29c4688ace466a365b85a51dcc5e3c853c1d283f293dfcc12f7a77e498f160d2",
+                "sha256:57214fa5430399dffd54f4be37b56fe22cedb2b98862550d43cc085fb698dc2c",
+                "sha256:577791f948d34d569acb2d1add5831731c59d5a0c50a6d9f629ae1cefd9ca4a0",
+                "sha256:6539314d84c4d36f28d73adc1b45e9f4ee2a89cdc7e5d2b0a6dbacba31906798",
+                "sha256:65867d63f0fd1b500fa343d7798fa64e9e681b594e0a07dc934c13e76ee28fb1",
+                "sha256:672b539db20fef6b03d6f7a14b5825d57c98e4026401fce838849f8de73fe4d4",
+                "sha256:6843db0343e12e3f52cc58430ad559d850a53684f5b352540ca3f1bc56df0731",
+                "sha256:7057613efefd36cacabbdbcef010e0a9c20a88fc07eb3e616019ea1692fa5df4",
+                "sha256:76ada88d62eb24de7051c5157a1a78fd853cca9b91c0713c2e973e4196271d0c",
+                "sha256:837398c2ec00228679513802e3744d1e8e3cb1204aa6ad408b6aff081e99a487",
+                "sha256:8662aabfeab00cea149a3d1c2999b0731e70c6b5bac596d95d13f643e76d3d4e",
+                "sha256:95e9094162fa712f18b4f60896e34b621df99147c2cee216cfa8f022294e8e9f",
+                "sha256:99cc66b33c418cd579c0f03b77b94263c305c389cb0c6972dac420f24b3bf123",
+                "sha256:9b219511d8b64d3fa14261963933be34028ea0e57455baf6781fe399c2c3206c",
+                "sha256:ae8f34d50af2c2154035984b8b5fc5d9ed63f32fe615646ab435b05b132ca91b",
+                "sha256:b9aa9d8818c2e917fa2c105ad538e222a5bce59777133840b93134022a7ce650",
+                "sha256:bf44a9a0141a082e89c90e8d785b212a872db793a0080c20f6ae6e2a0ebf82ad",
+                "sha256:c0b48b98d79cf795b0916c57bebbc6d16bb43b9fc9b8c9f57f4cf05881904c75",
+                "sha256:da9d3c506f43e220336433dffe643fbfa40096d408cb9b7f2477892f369d5f82",
+                "sha256:e4082d832e36e7f9b2278bc774886ca8207346b99f278e54c9de4834f17232f7",
+                "sha256:e4b9b7af398c32e408c00eb4e0d33ced2f9121fd9fb978e6c1b57edd014a7d15",
+                "sha256:e613514a82539fc48291d01933951a13ae93b6b444a88782480be32245ed4afa",
+                "sha256:f5033952def24172e60493b68717792e3aebb387a8d186c43c020d9363ee7281"
             ],
-            "version": "==1.14.1"
+            "version": "==1.14.2"
         },
         "chardet": {
             "hashes": [
@@ -92,28 +92,31 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0c608ff4d4adad9e39b5057de43657515c7da1ccb1807c3a27d4cf31fc923b4b",
-                "sha256:0cbfed8ea74631fe4de00630f4bb592dad564d57f73150d6f6796a24e76c76cd",
-                "sha256:124af7255ffc8e964d9ff26971b3a6153e1a8a220b9a685dc407976ecb27a06a",
-                "sha256:384d7c681b1ab904fff3400a6909261cae1d0939cc483a68bdedab282fb89a07",
-                "sha256:45741f5499150593178fc98d2c1a9c6722df88b99c821ad6ae298eff0ba1ae71",
-                "sha256:4b9303507254ccb1181d1803a2080a798910ba89b1a3c9f53639885c90f7a756",
-                "sha256:4d355f2aee4a29063c10164b032d9fa8a82e2c30768737a2fd56d256146ad559",
-                "sha256:51e40123083d2f946794f9fe4adeeee2922b581fa3602128ce85ff813d85b81f",
-                "sha256:8713ddb888119b0d2a1462357d5946b8911be01ddbf31451e1d07eaa5077a261",
-                "sha256:8e924dbc025206e97756e8903039662aa58aa9ba357d8e1d8fc29e3092322053",
-                "sha256:8ecef21ac982aa78309bb6f092d1677812927e8b5ef204a10c326fc29f1367e2",
-                "sha256:8ecf9400d0893836ff41b6f977a33972145a855b6efeb605b49ee273c5e6469f",
-                "sha256:9367d00e14dee8d02134c6c9524bb4bd39d4c162456343d07191e2a0b5ec8b3b",
-                "sha256:a09fd9c1cca9a46b6ad4bea0a1f86ab1de3c0c932364dbcf9a6c2a5eeb44fa77",
-                "sha256:ab49edd5bea8d8b39a44b3db618e4783ef84c19c8b47286bf05dfdb3efb01c83",
-                "sha256:bea0b0468f89cdea625bb3f692cd7a4222d80a6bdafd6fb923963f2b9da0e15f",
-                "sha256:bec7568c6970b865f2bcebbe84d547c52bb2abadf74cefce396ba07571109c67",
-                "sha256:ce82cc06588e5cbc2a7df3c8a9c778f2cb722f56835a23a68b5a7264726bb00c",
-                "sha256:dea0ba7fe6f9461d244679efa968d215ea1f989b9c1957d7f10c21e5c7c09ad6"
+                "sha256:10c9775a3f31610cf6b694d1fe598f2183441de81cedcf1814451ae53d71b13a",
+                "sha256:180c9f855a8ea280e72a5d61cf05681b230c2dce804c48e9b2983f491ecc44ed",
+                "sha256:247df238bc05c7d2e934a761243bfdc67db03f339948b1e2e80c75d41fc7cc36",
+                "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08",
+                "sha256:2a27615c965173c4c88f2961cf18115c08fedfb8bdc121347f26e8458dc6d237",
+                "sha256:2e26223ac636ca216e855748e7d435a1bf846809ed12ed898179587d0cf74618",
+                "sha256:321761d55fb7cb256b771ee4ed78e69486a7336be9143b90c52be59d7657f50f",
+                "sha256:4005b38cd86fc51c955db40b0f0e52ff65340874495af72efabb1bb8ca881695",
+                "sha256:4b9e96543d0784acebb70991ebc2dbd99aa287f6217546bb993df22dd361d41c",
+                "sha256:548b0818e88792318dc137d8b1ec82a0ab0af96c7f0603a00bb94f896fbf5e10",
+                "sha256:725875681afe50b41aee7fdd629cedbc4720bab350142b12c55c0a4d17c7416c",
+                "sha256:7a63e97355f3cd77c94bd98c59cb85fe0efd76ea7ef904c9b0316b5bbfde6ed1",
+                "sha256:94191501e4b4009642be21dde2a78bd3c2701a81ee57d3d3d02f1d99f8b64a9e",
+                "sha256:969ae512a250f869c1738ca63be843488ff5cc031987d302c1f59c7dbe1b225f",
+                "sha256:9f734423eb9c2ea85000aa2476e0d7a58e021bc34f0a373ac52a5454cd52f791",
+                "sha256:b45ab1c6ece7c471f01c56f5d19818ca797c34541f0b2351635a5c9fe09ac2e0",
+                "sha256:cc6096c86ec0de26e2263c228fb25ee01c3ff1346d3cfc219d67d49f303585af",
+                "sha256:dc3f437ca6353979aace181f1b790f0fc79e446235b14306241633ab7d61b8f8",
+                "sha256:e7563eb7bc5c7e75a213281715155248cceba88b11cb4b22957ad45b85903761",
+                "sha256:e7dad66a9e5684a40f270bd4aee1906878193ae50a4831922e454a2a457f1716",
+                "sha256:eb80a288e3cfc08f679f95da72d2ef90cb74f6d8a8ba69d2f215c5e110b2ca32",
+                "sha256:fa7fbcc40e2210aca26c7ac8a39467eae444d90a2c346cbcffd9133a166bcc67"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==3.0"
+            "version": "==3.1"
         },
         "docutils": {
             "hashes": [
@@ -155,11 +158,11 @@
         },
         "ping3": {
             "hashes": [
-                "sha256:73e2561d0b3b26a540749a1fcf3de2759df03c538a14dce89a40faf01b5f7742",
-                "sha256:a2d8edfbdc025e0b43f00689a7e8ad3e83bd1771394df5ec9563f0c1f09240c6"
+                "sha256:5f398f818fea9af615fdc4bd6e08b4654a04772bafbe69ca0cbbd346a29122a6",
+                "sha256:940305945ae9cd8551a5505957dd87abe664d81959063bccb91242185233db75"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.6.5"
+            "version": "==2.6.6"
         },
         "psutil": {
             "hashes": [
@@ -292,11 +295,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
+                "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==19.3.0"
+            "version": "==20.2.0"
         },
         "bandit": {
             "hashes": [
@@ -308,11 +311,11 @@
         },
         "black": {
             "hashes": [
-                "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b",
-                "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"
+                "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea",
+                "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"
             ],
             "index": "pypi",
-            "version": "==19.10b0"
+            "version": "==20.8b1"
         },
         "certifi": {
             "hashes": [
@@ -338,12 +341,12 @@
         },
         "codecov": {
             "hashes": [
-                "sha256:0be9cd6358cc6a3c01a1586134b0fb524dfa65ccbec3a40e9f28d5f976676ba2",
-                "sha256:65e8a8008e43eb45a9404bf68f8d4a60d36de3827ef2287971c94940128eba1e",
-                "sha256:fa7985ac6a3886cf68e3420ee1b5eb4ed30c4bdceec0f332d17ab69f545fbc90"
+                "sha256:24545847177a893716b3455ac5bfbafe0465f38d4eb86ea922c09adc7f327e65",
+                "sha256:355fc7e0c0b8a133045f0d6089bde351c845e7b52b99fec5903b4ea3ab5f6aab",
+                "sha256:7877f68effde3c2baadcff807a5d13f01019a337f9596eece0d64e57393adf3a"
             ],
             "index": "pypi",
-            "version": "==2.1.8"
+            "version": "==2.1.9"
         },
         "coverage": {
             "hashes": [
@@ -395,11 +398,11 @@
         },
         "freezegun": {
             "hashes": [
-                "sha256:82c757a05b7c7ca3e176bfebd7d6779fd9139c7cb4ef969c38a28d74deef89b2",
-                "sha256:e2062f2c7f95cc276a834c22f1a17179467176b624cc6f936e8bc3be5535ad1b"
+                "sha256:02b35de52f4699a78f6ac4518e4cd3390dddc43b0aeb978335a8f270a2d9668b",
+                "sha256:1cf08e441f913ff5e59b19cc065a8faa9dd1ddc442eaf0375294f344581a0643"
             ],
             "index": "pypi",
-            "version": "==0.3.15"
+            "version": "==1.0.0"
         },
         "gitdb": {
             "hashes": [
@@ -411,11 +414,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858",
-                "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"
+                "sha256:080bf8e2cf1a2b907634761c2eaefbe83b69930c94c66ad11b65a8252959f912",
+                "sha256:1858f4fd089abe92ae465f01d5aaaf55e937eca565fb2c1fce35a51b5f85c910"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==3.1.7"
+            "version": "==3.1.8"
         },
         "idna": {
             "hashes": [
@@ -424,12 +427,27 @@
             ],
             "version": "==2.8"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437",
+                "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"
+            ],
+            "version": "==1.0.1"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
+                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==8.5.0"
         },
         "mypy": {
             "hashes": [
@@ -458,6 +476,14 @@
             ],
             "version": "==0.4.3"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
+                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.4"
+        },
         "pathspec": {
             "hashes": [
                 "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0",
@@ -467,10 +493,27 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:07f558fece33b05caf857474a366dfcc00562bca13dd8b47b2b3e22d9f9bf55c",
-                "sha256:579170e23f8e0c2f24b0de612f71f648eccb79fb1322c814ae6b3c07b5ba23e8"
+                "sha256:14bfd98f51c78a3dd22a1ef45cf194ad79eee4a19e8e1a0d5c7f8e81ffe182ea",
+                "sha256:5adc0f9fc64319d8df5ca1e4e06eea674c26b80e6f00c530b18ce6a6592ead15"
             ],
-            "version": "==5.4.5"
+            "markers": "python_version >= '2.6'",
+            "version": "==5.5.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.9.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -487,6 +530,22 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40",
+                "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"
+            ],
+            "index": "pypi",
+            "version": "==6.0.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -564,11 +623,11 @@
         },
         "stevedore": {
             "hashes": [
-                "sha256:38791aa5bed922b0a844513c5f9ed37774b68edc609e5ab8ab8d8fe0ce4315e5",
-                "sha256:c8f4f0ebbc394e52ddf49de8bcc3cf8ad2b4425ebac494106bbc5e3661ac7633"
+                "sha256:5e1ab03eaae06ef6ce23859402de785f08d97780ed774948ef16c4652c41bc62",
+                "sha256:f845868b3a3a77a2489d226568abe7328b5c2d4f6a011cc759dfa99144a521f0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.2.0"
+            "version": "==3.2.2"
         },
         "toml": {
             "hashes": [
@@ -605,11 +664,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
-                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
-                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
+                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
+                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
-            "version": "==3.7.4.2"
+            "version": "==3.7.4.3"
         },
         "urllib3": {
             "hashes": [

--- a/docs/_includes/monitors.html
+++ b/docs/_includes/monitors.html
@@ -19,7 +19,7 @@ All monitor types share the following configuration options:
 | remote_alert| This monitor wants a remote host to handle alerting instead of the local host. Set to 1 to enable. This is a good candidate for putting in defaults if you want to use remote alerting for all your monitors. | no | 0 |
 | recover_command| A command to execute once when this monitor fails. It could, for example, restart a service if an HTTP check fails. | no | |
 | recovered_command| A command to execute once when this monitor succeeds the first time after being failed. | no | |
-| group | The group the monitor belongs to. Alerters will only fire for monitors which appear in their groups. | no | `default` |
+| group | The group the monitor belongs to. Alerters and Loggers will only fire for monitors which appear in their groups. | no | `default` |
 | notify | If the monitor should alert at all | no | 1 |
 | failure_doc | Information to include in alerts on failure (e.g. a URL to a runbook) | no | |
 {% for monitor in m %}

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -35,7 +35,7 @@ The section name should be the name of your alerter. This is the name you should
 | limit | the number of times a monitor must fail before this alerter will fire. You can use this to escalate an alert to another email address if the problem is ongoing for too long, for example. | no | 1 |
 | dry_run | makes an alerter do everything except actually send the message. Instead it will print some information about what it would do. Use when you want to test your configuration without generating emails/SMSes. Set to 1 to enable. | no | 0 |
 | ooh_success | makes an alerter trigger its success action even if out-of-hours (0 or 1) | no | 0 |
-| groups | comma-separated list of group names this alerter will fire for. See the `group` setting for monitors | no | `default` |
+| groups | comma-separated list of group names this alerter will fire for. Use `_all` to match all groups. See the `group` setting for monitors | no | `default` |
 | only_failures | set to 1 to only fire this alerters for failure notifications (or catchups), not recoveries | no | 0 |
 | tz | timezone to use in alert messages | no | UTC |
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -24,7 +24,7 @@ The section name should be the name of your logger. This is the name you should 
 |---|---|---|---|
 | type | the type of logger to create. Choose one of the five in the list above. | yes | |
 | depend | lists (comma-separated, no spaces) the names of the monitors this logger depends on. Use this if the database file lives over the network. If a monitor it depends on fails, no attempt will be made to update the database.| no | |
-| groups | comma-separated list of monitor groups this logger should operate for | no | "default" |
+| groups | comma-separated list of monitor groups this logger should operate for. Use `_all` to match all groups. | no | "default" |
 | tz | The [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) the logger should convert date/times to. | no | UTC |
 
 ### <a name="db"></a><a name="dbstatus"></a>db and dbstatus loggers

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+version = attr: simplemonitor.__version__
+
 [flake8]
 max-line-length = 88
 ignore = E501,W503,E203
@@ -5,6 +8,7 @@ per-file-ignores =
     simplemonitor/Monitors/__init__.py:F401
     simplemonitor/Loggers/__init__.py:F401
     simplemonitor/Alerters/__init__.py:F401
+    simplemonitor/__init__.py:F401
 
 [isort]
 known_third_party = arrow,freezegun,requests,setuptools,win32event,win32service,win32serviceutil

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,10 @@
 import setuptools
 
-from simplemonitor.version import VERSION
-
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="simplemonitor",
-    version=VERSION,
     author="James Seward",
     author_email="james@jamesoff.net",
     description="A simple network and host monitor",

--- a/simplemonitor/Alerters/alerter.py
+++ b/simplemonitor/Alerters/alerter.py
@@ -14,6 +14,7 @@ from ..Monitors.monitor import Monitor
 from ..util import (
     AlerterConfigurationError,
     MonitorState,
+    check_group_match,
     format_datetime,
     get_config_option,
     subclass_dict_handler,
@@ -216,7 +217,7 @@ class Alerter:
         if not self.available:
             return AlertType.NONE
 
-        if monitor.group not in self.groups:
+        if not check_group_match(monitor.group, self.groups):
             return AlertType.NONE
 
         if not self._allowed_today():

--- a/simplemonitor/Alerters/alerter.py
+++ b/simplemonitor/Alerters/alerter.py
@@ -216,6 +216,9 @@ class Alerter:
         if not self.available:
             return AlertType.NONE
 
+        if monitor.group not in self.groups:
+            return AlertType.NONE
+
         if not self._allowed_today():
             out_of_hours = True
 

--- a/simplemonitor/Loggers/mqtt.py
+++ b/simplemonitor/Loggers/mqtt.py
@@ -75,11 +75,21 @@ class MQTTLogger(Logger):
         )
         # username for authentication
         self.username = cast(
-            str, self.get_config_option("username", required=False, allow_empty=True,),
+            str,
+            self.get_config_option(
+                "username",
+                required=False,
+                allow_empty=True,
+            ),
         )
         # password for authentication
         self.password = cast(
-            str, self.get_config_option("password", required=False, allow_empty=True,),
+            str,
+            self.get_config_option(
+                "password",
+                required=False,
+                allow_empty=True,
+            ),
         )
 
         if self.username and self.password:

--- a/simplemonitor/__init__.py
+++ b/simplemonitor/__init__.py
@@ -1,0 +1,1 @@
+from .version import VERSION as __version__

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -546,8 +546,16 @@ class SimpleMonitor:
                     )
             try:
                 for host_monitors in self.remote_monitors.values():
-                    for (name, monitor) in host_monitors.items():
-                        logger.save_result2(name, monitor)
+                    for name, monitor in host_monitors.items():
+                        if monitor.group in logger.groups:
+                            logger.save_result2(name, monitor)
+                        else:
+                            module_logger.debug(
+                                "not logging for %s due to group mismatch (monitor in group %s, logger has groups %s",
+                                name,
+                                monitor.group,
+                                logger.groups,
+                            )
             except Exception:  # pragma: no cover
                 module_logger.exception("exception while logging remote monitors")
 

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -21,7 +21,7 @@ from .Loggers.network import Listener
 from .Monitors.monitor import Monitor
 from .Monitors.monitor import all_types as all_monitor_types
 from .Monitors.monitor import get_class as get_monitor_class
-from .util import get_config_dict
+from .util import check_group_match, get_config_dict
 from .util.envconfig import EnvironmentAwareConfigParser
 
 module_logger = logging.getLogger("simplemonitor")
@@ -534,7 +534,7 @@ class SimpleMonitor:
         logger.check_dependencies(self.failed + self.still_failing + self.skipped)
         with logger:
             for key, monitor in self.monitors.items():
-                if monitor.group in logger.groups:
+                if check_group_match(monitor.group, logger.groups):
                     logger.save_result2(key, monitor)
                 else:
                     module_logger.debug(
@@ -547,11 +547,12 @@ class SimpleMonitor:
             try:
                 for host_monitors in self.remote_monitors.values():
                     for name, monitor in host_monitors.items():
-                        if monitor.group in logger.groups:
+                        if check_group_match(monitor.group, logger.groups):
                             logger.save_result2(name, monitor)
                         else:
                             module_logger.debug(
-                                "not logging for %s due to group mismatch (monitor in group %s, logger has groups %s",
+                                "not logging for %s due to group mismatch (monitor in group %s, "
+                                "logger has groups %s",
                                 name,
                                 monitor.group,
                                 logger.groups,

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -554,33 +554,20 @@ class SimpleMonitor:
     def do_alert(self, alerter: Alerter) -> None:
         """Use the given alerter object to send an alert, if needed."""
         alerter.check_dependencies(self.failed + self.still_failing + self.skipped)
-        for key in list(self.monitors.keys()):
-            this_monitor = self.monitors[key]  # type: Monitor
+        for (name, this_monitor) in list(self.monitors.items()):
             # Don't generate alerts for monitors which want it done remotely
             if this_monitor.remote_alerting:
                 module_logger.debug(
-                    "skipping alert for monitor %s as it wants remote alerting", key
+                    "skipping alert for monitor %s as it wants remote alerting", name
                 )
                 continue
             try:
-                if this_monitor.group in alerter.groups:
-                    # Only notifications for services that have it enabled
-                    if this_monitor.notify:
-                        module_logger.debug("notifying alerter %s", alerter.name)
-                        alerter.send_alert(key, self.monitors[key])
-                    else:
-                        module_logger.warning(
-                            "monitor %s has notifications disabled", key
-                        )
+                if this_monitor.notify:
+                    alerter.send_alert(name, this_monitor)
                 else:
-                    module_logger.info(
-                        "skipping alerter %s as monitor %s is not in group %s",
-                        alerter.name,
-                        this_monitor.name,
-                        alerter.groups,
-                    )
+                    module_logger.warning("monitor %s has notifications disabled", name)
             except Exception:  # pragma: no cover
-                module_logger.exception("exception caught while alerting for %s", key)
+                module_logger.exception("exception caught while alerting for %s", name)
         for host_monitors in self.remote_monitors.values():
             for (name, monitor) in host_monitors.items():
                 try:

--- a/simplemonitor/util/__init__.py
+++ b/simplemonitor/util/__init__.py
@@ -222,3 +222,16 @@ def subclass_dict_handler(
         return list(_subclasses)
 
     return (register, get_class, all_types)
+
+
+def check_group_match(group: str, group_list: List[str]) -> bool:
+    """
+    Check if a group is contained in the group list.
+
+    If the group list is a single element, "_all", then it matches.
+    """
+    if group_list[0] == "_all":
+        return True
+    if group in group_list:
+        return True
+    return False

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -341,6 +341,30 @@ class TestAlerter(unittest.TestCase):
             self.assertEqual(a.should_alert(m), alerter.AlertType.FAILURE)
             self.assertEqual(a._ooh_failures, [])
 
+    def test_skip_group_alerter(self):
+        a = alerter.Alerter({"groups": "test"})
+        m = monitor.MonitorFail("fail", {})
+        m.run_test()
+        self.assertEqual(a.should_alert(m), alerter.AlertType.NONE)
+
+    def test_skip_group_monitor(self):
+        a = alerter.Alerter()
+        m = monitor.MonitorFail("fail", {"group": "test"})
+        m.run_test()
+        self.assertEqual(a.should_alert(m), alerter.AlertType.NONE)
+
+    def test_groups_match(self):
+        a = alerter.Alerter({"groups": "test"})
+        m = monitor.MonitorFail("fail", {"group": "test"})
+        m.run_test()
+        self.assertEqual(a.should_alert(m), alerter.AlertType.FAILURE)
+
+    def test_groups_multi_match(self):
+        a = alerter.Alerter({"groups": "test1, test2"})
+        m = monitor.MonitorFail("fail", {"group": "test1"})
+        m.run_test()
+        self.assertEqual(a.should_alert(m), alerter.AlertType.FAILURE)
+
 
 class TestMessageBuilding(unittest.TestCase):
     def setUp(self):

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -365,6 +365,12 @@ class TestAlerter(unittest.TestCase):
         m.run_test()
         self.assertEqual(a.should_alert(m), alerter.AlertType.FAILURE)
 
+    def test_groups_all_match(self):
+        a = alerter.Alerter({"groups": "_all"})
+        m = monitor.MonitorFail("fail", {"group": "test1"})
+        m.run_test()
+        self.assertEqual(a.should_alert(m), alerter.AlertType.FAILURE)
+
 
 class TestMessageBuilding(unittest.TestCase):
     def setUp(self):

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -98,7 +98,7 @@ class TestHostMonitors(unittest.TestCase):
         m = host.MonitorDiskSpace("test", config_options)
         m.run_test()
         self.assertFalse(m.test_success(), "Monitor did not fail")
-        self.assertRegexpMatches(
+        self.assertRegex(
             m.last_result,
             "Couldn't get free disk space",
             "Monitor did not report error correctly",

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -99,6 +99,14 @@ class TestLogger(unittest.TestCase):
             s.log_result(this_logger)
         mock_method.assert_called_once()
 
+    def test_groups_all_match(self):
+        with patch.object(logger.Logger, "save_result2") as mock_method:
+            this_logger = logger.Logger({"groups": "_all"})
+            s = SimpleMonitor(Path("tests/monitor-empty.ini"))
+            s.add_monitor("test", MonitorNull("unnamed", {"group": "test1"}))
+            s.log_result(this_logger)
+        mock_method.assert_called_once()
+
 
 class TestFileLogger(unittest.TestCase):
     @freeze_time("2020-04-18 12:00+00:00")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -67,6 +67,38 @@ class TestLogger(unittest.TestCase):
             s.log_result(this_logger)
         mock_method.assert_called_once()
 
+    def test_skip_group_logger(self):
+        with patch.object(logger.Logger, "save_result2") as mock_method:
+            this_logger = logger.Logger({"groups": "test"})
+            s = SimpleMonitor(Path("tests/monitor-empty.ini"))
+            s.add_monitor("test", MonitorNull("unnamed", {}))
+            s.log_result(this_logger)
+        mock_method.assert_not_called()
+
+    def test_skip_group_monitor(self):
+        with patch.object(logger.Logger, "save_result2") as mock_method:
+            this_logger = logger.Logger({})
+            s = SimpleMonitor(Path("tests/monitor-empty.ini"))
+            s.add_monitor("test", MonitorNull("unnamed", {"group": "test"}))
+            s.log_result(this_logger)
+        mock_method.assert_not_called()
+
+    def test_groups_match(self):
+        with patch.object(logger.Logger, "save_result2") as mock_method:
+            this_logger = logger.Logger({"groups": "test"})
+            s = SimpleMonitor(Path("tests/monitor-empty.ini"))
+            s.add_monitor("test", MonitorNull("unnamed", {"group": "test"}))
+            s.log_result(this_logger)
+        mock_method.assert_called_once()
+
+    def test_groups_multi_match(self):
+        with patch.object(logger.Logger, "save_result2") as mock_method:
+            this_logger = logger.Logger({"groups": "test1, test2"})
+            s = SimpleMonitor(Path("tests/monitor-empty.ini"))
+            s.add_monitor("test", MonitorNull("unnamed", {"group": "test1"}))
+            s.log_result(this_logger)
+        mock_method.assert_called_once()
+
 
 class TestFileLogger(unittest.TestCase):
     @freeze_time("2020-04-18 12:00+00:00")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -128,7 +128,8 @@ class TestFileLogger(unittest.TestCase):
                 "2020-04-18 12:00:00+00:00 simplemonitor starting",
             )
             self.assertEqual(
-                fh.readline().strip(), "2020-04-18 12:00:00+00:00 null: ok (0.000s)",
+                fh.readline().strip(),
+                "2020-04-18 12:00:00+00:00 null: ok (0.000s)",
             )
         try:
             os.unlink(temp_logfile)
@@ -152,7 +153,8 @@ class TestFileLogger(unittest.TestCase):
                 "2020-04-18 11:00:00+00:00 simplemonitor starting",
             )
             self.assertEqual(
-                fh.readline().strip(), "2020-04-18 11:00:00+00:00 null: ok (0.000s)",
+                fh.readline().strip(),
+                "2020-04-18 11:00:00+00:00 null: ok (0.000s)",
             )
         try:
             os.unlink(temp_logfile)
@@ -181,7 +183,8 @@ class TestFileLogger(unittest.TestCase):
                 "2020-04-18 13:00:00+02:00 simplemonitor starting",
             )
             self.assertEqual(
-                fh.readline().strip(), "2020-04-18 13:00:00+02:00 null: ok (0.000s)",
+                fh.readline().strip(),
+                "2020-04-18 13:00:00+02:00 null: ok (0.000s)",
             )
         try:
             os.unlink(temp_logfile)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -36,10 +36,14 @@ class TestMonitor(unittest.TestCase):
         time.sleep(2)
         Path(temp_file_name).touch()
         self.assertEqual(
-            s._check_hup_file(), True, "check_hup_file did not trigger",
+            s._check_hup_file(),
+            True,
+            "check_hup_file did not trigger",
         )
         self.assertEqual(
-            s._check_hup_file(), False, "check_hup_file should not have triggered",
+            s._check_hup_file(),
+            False,
+            "check_hup_file should not have triggered",
         )
         os.unlink(temp_file_name)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -165,3 +165,17 @@ class TestUpDownTime(unittest.TestCase):
 
         u2 = util.UpDownTime(2, 2, 3, 4)
         self.assertNotEqual(u1, u2)
+
+
+class TestGroupMatch(unittest.TestCase):
+    def test_simple(self):
+        self.assertTrue(util.check_group_match("default", ["default"]))
+
+    def test_list(self):
+        self.assertTrue(util.check_group_match("test", ["test", "test2"]))
+
+    def test_not_list(self):
+        self.assertFalse(util.check_group_match("default", ["test1", "test2"]))
+
+    def test_all(self):
+        self.assertTrue(util.check_group_match("test", ["_all"]))


### PR DESCRIPTION
Fixes an issue where remote monitors did not have their `group` evaluated for logging and alerting.

Adds a pseudo group `_all` which Loggers and Alerters can belong to (by itself) which matches all other groups for Monitors.