### PR TITLE
Add seq as a logger option

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -13,6 +13,7 @@ The types of loggers are:
 * [logfile](#logfile): Records a logfile of the result of every monitor, or only the monitors which failed. Each line is preceeded by the current UNIX timestamp.
 * [html](#html): Writes an HTML file showing the status of all monitors (including remote ones).
 * [network](#network): Sends status of all monitors to a remote host.
+* [seq](#seq): Sends status of all monitors to a seq log server
 * [json](#json): Writes a JSON file describing the state of all the monitors
 * [mqtt](#mqtt): Send monitor state via MQTT
 
@@ -57,6 +58,16 @@ The section name should be the name of your logger. This is the name you should 
 The supplied header file includes JavaScript to notify you if the page either doesn’t auto-refresh, or if SimpleMonitor has stopped updating it. This requires your machine running SimpleMonitor and the machine you are browsing from to agree on what the time is (timezone doesn’t matter)!
 
 You can use the `upload_command` setting to specify a command to push the generated files to another location (e.g. a web server, an S3 bucket etc). I'd suggest putting the commands in a script and just specifying that script as the value for this setting.
+
+### <a name="seq"></a>seq logger
+
+This logger is used to send status reports of all monitors to a seq log server. The logger must be configured with the seq *endpoint* parameter, for example http://10.0.0.100:5341/api/events/raw 
+
+| setting | description | required | default |
+|---|---|---|---|
+| endpoint | Full URI for the endoint on the seq server  (e.g. http://localhost:5341/api/events/seq) | yes | |
+
+From their website, 'Seq creates the visibility you need to quickly identify and diagnose problems in complex applications and microservices'. See https://datalust.co for more information on Seq
 
 ### <a name="network"></a>network logger
 

--- a/simplemonitor/Loggers/__init__.py
+++ b/simplemonitor/Loggers/__init__.py
@@ -6,3 +6,4 @@ from .db import DBFullLogger, DBStatusLogger
 from .file import FileLogger
 from .mqtt import MQTTLogger
 from .network import Listener, NetworkLogger
+from .seq import SeqLogger

--- a/simplemonitor/Loggers/seq.py
+++ b/simplemonitor/Loggers/seq.py
@@ -75,19 +75,16 @@ class SeqLogger(Logger):
 
         request_body = {"Events": [event_data]}
      
-        print(is_fail)
-        print(request_body)
-
         try:
-            request_body_json = json.dumps(request_body)  # This just checks it is valid...
+            _ = json.dumps(request_body)  # This just checks it is valid...
         except TypeError:
-            self.log(f"Could not serialize {request_body}")
+            self.alerter_logger.error("Could not serialise %s", request_body) 
             return
     
         try:
             r = requests.post(self.endpoint, json=request_body)
             if not r.status_code == 200 and not r.status_code == 201:
-                self.alerter_logger.error("POST to slack webhook failed: %s", r)
+                self.alerter_logger.error("POST to seq failed with status code: %s", r)
         except Exception:
             self.alerter_logger.exception("Failed to log to seq")
 

--- a/simplemonitor/Loggers/seq.py
+++ b/simplemonitor/Loggers/seq.py
@@ -43,13 +43,29 @@ class SeqLogger(Logger):
         # Potentially, would need to add a header for ApiKey
 
         # Send message to indicate we have started logging
-        self.log_to_seq(self.endpoint, 'SeqLogger', 'simpleMonitor', '__init__', None, 'logging enabled for simpleMonitor', False)
+        self.log_to_seq(
+            self.endpoint,
+            "SeqLogger",
+            "simpleMonitor",
+            "__init__",
+            None,
+            "logging enabled for simpleMonitor",
+            False,
+        )
 
     def save_result2(self, name: str, monitor: Monitor) -> None:
         try:
             is_fail = monitor.test_success() is False
 
-            self.log_to_seq(self.endpoint, name, monitor.name, monitor.monitor_type, str(monitor.get_params()), monitor.describe(), is_fail)
+            self.log_to_seq(
+                self.endpoint,
+                name,
+                monitor.name,
+                monitor.monitor_type,
+                str(monitor.get_params()),
+                monitor.describe(),
+                is_fail,
+            )
         except Exception:
             self.logger_logger.exception("Error sending to seq in %s", monitor.name)
 
@@ -57,7 +73,9 @@ class SeqLogger(Logger):
         return "Sends simple log to seq using raw endpoint"
         # From https://raw.githubusercontent.com/eifinger/appdaemon-scripts/master/seqSink/seqSink.py
 
-    def log_to_seq(self, endpoint, name, app_name, monitor_type, params, description, is_fail):
+    def log_to_seq(
+        self, endpoint, name, app_name, monitor_type, params, description, is_fail
+    ):
         event_data = {
             "Timestamp": str(datetime.datetime.now()),
             "Level": "Error" if is_fail is True else "Information",
@@ -74,17 +92,16 @@ class SeqLogger(Logger):
             event_data["Properties"]["Params"] = params
 
         request_body = {"Events": [event_data]}
-     
+
         try:
             _ = json.dumps(request_body)  # This just checks it is valid...
         except TypeError:
-            self.alerter_logger.error("Could not serialise %s", request_body) 
+            self.alerter_logger.error("Could not serialise %s", request_body)
             return
-    
+
         try:
             r = requests.post(self.endpoint, json=request_body)
             if not r.status_code == 200 and not r.status_code == 201:
                 self.alerter_logger.error("POST to seq failed with status code: %s", r)
         except Exception:
             self.alerter_logger.exception("Failed to log to seq")
-

--- a/simplemonitor/Loggers/seq.py
+++ b/simplemonitor/Loggers/seq.py
@@ -1,0 +1,93 @@
+# coding=utf-8
+
+# Simplemonitor logger for seq
+# Inspiration from https://raw.githubusercontent.com/eifinger/appdaemon-scripts/master/seqSink/seqSink.py
+# Python 3 only
+
+try:
+    import json
+    import requests
+    import datetime
+
+    from typing import cast
+
+    from ..Monitors.monitor import Monitor
+    from .logger import Logger, register
+
+    is_available = True
+
+except ImportError:
+    is_available = False
+
+
+@register
+class SeqLogger(Logger):
+    logger_type = "seq"
+    only_failures = False
+    buffered = False
+    dateformat = None
+
+    def __init__(self, config_options: dict = None) -> None:
+        if config_options is None:
+            config_options = {}
+        super().__init__(config_options)
+
+        if not is_available:
+            self.logger_logger.error("Missing modules!")
+            return
+
+        # i.e. http://192.168.0.5:5341
+        self.endpoint = cast(
+            str, self.get_config_option("endpoint", required=True, allow_empty=False)
+        )
+        # Potentially, would need to add a header for ApiKey
+
+        # Send message to indicate we have started logging
+        self.log_to_seq(self.endpoint, 'SeqLogger', 'simpleMonitor', '__init__', None, 'logging enabled for simpleMonitor', False)
+
+    def save_result2(self, name: str, monitor: Monitor) -> None:
+        try:
+            is_fail = monitor.test_success() is False
+
+            self.log_to_seq(self.endpoint, name, monitor.name, monitor.monitor_type, str(monitor.get_params()), monitor.describe(), is_fail)
+        except Exception:
+            self.logger_logger.exception("Error sending to seq in %s", monitor.name)
+
+    def describe(self) -> str:
+        return "Sends simple log to seq using raw endpoint"
+        # From https://raw.githubusercontent.com/eifinger/appdaemon-scripts/master/seqSink/seqSink.py
+
+    def log_to_seq(self, endpoint, name, app_name, monitor_type, params, description, is_fail):
+        event_data = {
+            "Timestamp": str(datetime.datetime.now()),
+            "Level": "Error" if is_fail is True else "Information",
+            "MessageTemplate": str(description),
+            "Properties": {
+                "Type": "simpleMonitor",
+                "Name": name,
+                "Monitor": str(app_name),
+                "MonitorType": monitor_type,
+                # "Params": params
+            },
+        }
+        if params is not None:
+            event_data["Properties"]["Params"] = params
+
+        request_body = {"Events": [event_data]}
+     
+        print(is_fail)
+        print(request_body)
+
+        try:
+            request_body_json = json.dumps(request_body)  # This just checks it is valid...
+        except TypeError:
+            self.log(f"Could not serialize {request_body}")
+            return
+    
+        try:
+            r = requests.post(self.endpoint, json=request_body)
+            if not r.status_code == 200 and not r.status_code == 201:
+                self.alerter_logger.error("POST to slack webhook failed: %s", r)
+        except Exception:
+            self.alerter_logger.exception("Failed to log to seq")
+


### PR DESCRIPTION
As mentioned in #641, a PR to include seq as a logger.

Like all of the loggers, its straightforward to configure. For example add to the monitor.ini file:

```
[reporting]
loggers=seq

[seq]
type=seq
endpoint=http://1.2.3.4:5341/api/events/raw
```

The default seq port is 5341 and this logger uses the simple 'raw' endpoint. There are seq log handlers available for Python however I wanted a simple no-dependency method to send seq log event data. 

All constructive or otherwise comments welcome about this PR :-)

