### PR TITLE
Run monitors in multiple threads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,8 @@ jobs:
         run: poetry install
       - name: Integration tests
         run: make integration-tests
+      - name: Integration tests (threaded)
+        run: make integration-tests-threaded
       - name: Config environment variables tests
         run: make env-test
       - name: Unit tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,8 @@ jobs:
         run: mkdir html
       - name: Integration tests
         run: make integration-tests
+      - name: Integration tests (threaded)
+        run: make integration-tests-threaded
       - name: Unit tests
         run: make unit-test
       - uses: codecov/codecov-action@v1

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ flake8:
 	poetry run flake8 *.py simplemonitor/
 
 integration-tests:
+	PATH="$(MOCKSPATH)$(PATH)" $(PIPENV) run coverage run monitor.py -1 -v -d -f $(INTEGRATION_CONFIG) -j 1
+
+integration-tests-threaded:
 	PATH="$(MOCKSPATH)$(PATH)" $(PIPENV) run coverage run monitor.py -1 -v -d -f $(INTEGRATION_CONFIG)
 
 env-test:

--- a/simplemonitor/Monitors/monitor.py
+++ b/simplemonitor/Monitors/monitor.py
@@ -64,8 +64,9 @@ class Monitor:
         self.name = name
         self._deps = []  # type: List[str]
         self.monitor_logger = logging.getLogger("simplemonitor.monitor-" + self.name)
-        self._dependencies = self.get_config_option(
-            "depend", required_type="[str]", default=list()
+        self._dependencies = cast(
+            List[str],
+            self.get_config_option("depend", required_type="[str]", default=list()),
         )
         self._urgent = self.get_config_option(
             "urgent", required_type="bool", default=True

--- a/simplemonitor/monitor.py
+++ b/simplemonitor/monitor.py
@@ -4,6 +4,7 @@
 
 import argparse
 import logging
+import os
 import sys
 
 from .simplemonitor import SimpleMonitor
@@ -78,6 +79,16 @@ def main() -> None:
         help=(
             "configuration file (this is the main config; "
             "you also need monitors.ini (default filename)"
+        ),
+    )
+    parser.add_argument(
+        "-j",
+        "--threads",
+        dest="threads",
+        default=os.cpu_count(),  # default used by the library anyway
+        type=int,
+        help=(
+            f"number of threads to run for checking monitors (default (cpus): {os.cpu_count()})"
         ),
     )
     output_group.add_argument(
@@ -204,6 +215,7 @@ def main() -> None:
         max_loops=options.loops,
         heartbeat=not options.no_heartbeat,
         one_shot=options.one_shot,
+        max_workers=options.threads,
     )
 
     if options.test:

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -464,6 +464,11 @@ class SimpleMonitor:
             failed = self._failed_monitors()
             module_logger.debug("Starting loop with joblist %s", joblist)
             for monitor in joblist:
+                if monitor in failed:
+                    module_logger.error(
+                        "Received a failed logger in the joblist: %s", monitor
+                    )
+                    continue
                 module_logger.debug("Trying monitor: %s", monitor)
                 if self.monitors[monitor].remaining_dependencies:
                     # this monitor has outstanding deps, put it on the new joblist for next loop

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -472,18 +472,20 @@ class SimpleMonitor:
         if monitor.error_count > 0:
             if monitor.virtual_fail_count() == 0:
                 module_logger.warning(
-                    "monitor failed but within tolerance: %s", monitor.name
+                    "monitor failed but within tolerance: %s (%s)",
+                    monitor.name,
+                    monitor.last_result,
                 )
             else:
                 module_logger.error(
                     "monitor failed: %s (%s)",
-                    monitor,
+                    monitor.name,
                     monitor.last_result,
                 )
             return False
         if not did_run:
             return False
-        module_logger.info("monitor passed: %s", monitor)
+        module_logger.info("monitor passed: %s", monitor.name)
         return True
 
     def run_tests(self) -> None:
@@ -522,7 +524,11 @@ class SimpleMonitor:
                         skiplist.append(monitor)
                     else:
                         new_joblist.append(monitor)
-                        module_logger.debug("Added %s to new joblist", monitor)
+                        module_logger.debug(
+                            "Added %s to new joblist due to outstanding deps %s",
+                            monitor,
+                            ", ".join(self.monitors[monitor].remaining_dependencies),
+                        )
                     continue
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 future_to_monitor = {}

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -40,7 +40,8 @@ class SimpleMonitor:
         no_network: bool = False,
         max_loops: int = -1,
         heartbeat: bool = True,
-        one_shot: bool = False
+        one_shot: bool = False,
+        max_workers: Optional[int] = None
     ) -> None:
         """Main class turn on."""
         if isinstance(config_file, str):
@@ -69,6 +70,7 @@ class SimpleMonitor:
         self.heartbeat = heartbeat
         self.one_shot = one_shot
         self.pidfile = None  # type: Optional[str]
+        self._max_workers = max_workers
 
         self._setup_signals()
         self._load_config()
@@ -497,7 +499,9 @@ class SimpleMonitor:
         while joblist:
             new_joblist, skiplist = self._prepare_lists(joblist)
             joblist = self.sort_joblist(joblist)
-            with concurrent.futures.ThreadPoolExecutor() as executor:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=self._max_workers
+            ) as executor:
                 future_to_monitor = {}
                 for monitor in joblist:
                     if monitor in new_joblist or monitor in skiplist:

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -493,7 +493,6 @@ class SimpleMonitor:
         self.reset_monitors()
 
         joblist = [k for (k, v) in self.monitors.items() if v.enabled]
-        joblist = self.sort_joblist(joblist)
         while joblist:
             new_joblist = []  # type: List[str]
             skiplist = []  # type: List[str]
@@ -530,6 +529,7 @@ class SimpleMonitor:
                             ", ".join(self.monitors[monitor].remaining_dependencies),
                         )
                     continue
+            joblist = self.sort_joblist(joblist)
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 future_to_monitor = {}
                 for monitor in joblist:


### PR DESCRIPTION
Use threading to run the monitors in parallel.
Add a `-j/--threads` option to control the number of threads.
Refactor the logic for preparing the skiplist/new joblist, and improve the logic handling Compound monitors.

Closes #559 