### PR TITLE
Fix double-call to record_fail in MonitorUnixService

### DIFF
--- a/simplemonitor/Monitors/service.py
+++ b/simplemonitor/Monitors/service.py
@@ -209,18 +209,15 @@ class MonitorUnixService(Monitor):
         try:
             result = subprocess.run(
                 ["service", self.service_name, "status"],
-                check=True,
+                check=False,
                 stderr=subprocess.PIPE,
                 stdout=subprocess.PIPE,
             )  # nosec
             returncode = result.returncode
-        except subprocess.CalledProcessError as exception:
-            returncode = exception.returncode
-            if returncode == self._want_return_code:
-                return self.record_success()
-            self.record_fail(
+        except subprocess.SubprocessError as exception:
+            return self.record_fail(
                 "Failed to run 'service {} status: {}".format(
-                    self.service_name, exception.output
+                    self.service_name, exception
                 )
             )
         if returncode == self._want_return_code:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,56 @@
+# type: ignore
+import unittest
+import subprocess
+from simplemonitor.Monitors import service
+from unittest.mock import patch
+
+
+class TestUnixServiceMonitors(unittest.TestCase):
+    @patch("subprocess.run")
+    def test_UnixService_ok(self, subprocess_run_fn):
+        config_options = {"service": "unittest"}
+
+        subprocess_run_fn.return_value = subprocess.CompletedProcess(
+            ["service", config_options.get("service"), "status"], returncode=1
+        )
+        m = service.MonitorUnixService("unittest", config_options)
+
+        m.run_test()
+        self.assertFalse(m.test_success())
+        self.assertEqual(m.error_count, 1)
+
+        m.run_test()
+        self.assertFalse(m.test_success())
+        self.assertEqual(m.error_count, 2)
+
+    @patch("subprocess.run")
+    def test_UnixService_raiseFileNotFoundError(self, subprocess_run_fn):
+        config_options = {"service": "unittest"}
+
+        subprocess_run_fn.side_effect = FileNotFoundError(
+            "[Errno 2] No such file or directory: 'service'"
+        )
+        m = service.MonitorUnixService("unittest", config_options)
+
+        self.assertRaises(FileNotFoundError, m.run_test)
+
+    @patch("subprocess.run")
+    def test_UnixService_raiseSubprocessError(self, subprocess_run_fn):
+        config_options = {"service": "unittest"}
+
+        subprocess_run_fn.side_effect = subprocess.SubprocessError(
+            ["service", config_options.get("service"), "status"]
+        )
+        m = service.MonitorUnixService("unittest", config_options)
+
+        m.run_test()
+        self.assertFalse(m.test_success())
+        self.assertEqual(m.error_count, 1)
+
+        m.run_test()
+        self.assertFalse(m.test_success())
+        self.assertEqual(m.error_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
When Exception gets raised self.record_fail() is called two times: inside the exception
handler and then at the end of the function, causing the virtual fail count to increment by 2
instead of just 1