### PR TITLE
Fix issues with OOH alerts and Compound monitors

### DIFF
--- a/simplemonitor/Monitors/compound.py
+++ b/simplemonitor/Monitors/compound.py
@@ -77,15 +77,6 @@ class CompoundMonitor(Monitor):
             if i not in list(self.m.keys()):
                 raise RuntimeError("No such monitor %s in compound monitor" % i)
 
-    def virtual_fail_count(self) -> int:
-        failcount = self.fail_count()
-        if failcount >= self.min_fail:
-            # greater or equal number failed: we return the real failure count
-            return failcount
-        else:
-            # we don't count failures if the specified min_fail isn't reached yet.
-            return 0
-
     def fail_count(self) -> int:
         """increments the fail counter by 1 if a sub-monitor failed"""
         failcount = 0

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -356,7 +356,7 @@ class TestMonitor(unittest.TestCase):
         self.assertEqual(result, False, "compound monitor should have failed")
         self.assertEqual(
             compound_monitor.virtual_fail_count(),
-            2,
+            1,
             "compound monitor should report fail count",
         )
         self.assertEqual(


### PR DESCRIPTION
Resolve issues where `should_alert()` would fall though to FAILURE and send an alert when it shouldn't, and an implementation quirk of Compound monitors where they could repeatedly alert.