### PR TITLE
do not raise exception on empty network data

### DIFF
--- a/simplemonitor/Loggers/network.py
+++ b/simplemonitor/Loggers/network.py
@@ -159,6 +159,9 @@ class Listener(Thread):
                         break
                     serialized += data
                 conn.close()
+                if len(data) == 0:
+                    self.logger.debug("No data from %s", addr[0])
+                    continue
                 self.logger.debug("Finished receiving from %s", addr[0])
                 try:
                     # first byte is the size of the MAC


### PR DESCRIPTION
When monitoring the network logger itself with the tcp monitor,
simplmonitor raises an exception and spams the log. Silence this
exception and only print a debug message.