### PR TITLE
Added allow_redirects for http monitor

### DIFF
--- a/docs/monitors/http.rst
+++ b/docs/monitors/http.rst
@@ -26,6 +26,30 @@ Attempts to fetch a URL and makes sure the HTTP return code is (by default) 200/
 
     a list of acceptable HTTP status codes
 
+.. confval:: allow_redirects
+
+    :type: bool
+    :required: false
+    :default: `true`
+
+    Follow redirects
+
+.. confval:: username
+
+    :type: str
+    :required: false
+    :default: none
+
+    Username for http basic auth
+
+.. confval:: password
+
+    :type: str
+    :required: false
+    :default: none
+
+    Password for http basic auth
+
 .. confval:: verify_hostname
 
     :type: boolean

--- a/simplemonitor/Monitors/network.py
+++ b/simplemonitor/Monitors/network.py
@@ -33,6 +33,7 @@ class MonitorHTTP(Monitor):
     regexp = None
     regexp_text = ""
     allowed_codes = []  # type: List[int]
+    allow_redirects = True  # type: bool
 
     monitor_type = "http"
 
@@ -51,11 +52,17 @@ class MonitorHTTP(Monitor):
         if regexp is not None:
             self.regexp = re.compile(regexp)
             self.regexp_text = regexp
+
         self.allowed_codes = self.get_config_option(
             "allowed_codes", default=[200], required_type="[int]"
         )
+        self.allow_redirects = self.get_config_option(
+            "allow_redirects",
+            default=True,
+            required_type="bool",
+        )
 
-        # optionnal - for HTTPS client authentication only
+        # optional - for HTTPS client authentication only
         # in this case, certfile is required
         self.certfile = cast(Optional[str], config_options.get("certfile"))
         self.keyfile = cast(Optional[str], config_options.get("keyfile"))
@@ -89,6 +96,7 @@ class MonitorHTTP(Monitor):
                     timeout=self.request_timeout,
                     verify=self.verify_hostname,
                     headers=self.headers,
+                    allow_redirects=self.allow_redirects,
                 )
             elif self.certfile is None and self.username is not None:
                 response = requests.get(
@@ -97,6 +105,7 @@ class MonitorHTTP(Monitor):
                     auth=HTTPBasicAuth(self.username, self.password),
                     verify=self.verify_hostname,
                     headers=self.headers,
+                    allow_redirects=self.allow_redirects,
                 )
             else:
                 assert self.certfile is not None and self.keyfile is not None
@@ -106,6 +115,7 @@ class MonitorHTTP(Monitor):
                     cert=(self.certfile, self.keyfile),
                     verify=self.verify_hostname,
                     headers=self.headers,
+                    allow_redirects=self.allow_redirects,
                 )
 
             end_time = arrow.get()

--- a/tests/test_network_new.py
+++ b/tests/test_network_new.py
@@ -1,0 +1,78 @@
+import unittest
+
+from requests import Response
+from requests.auth import HTTPBasicAuth
+from unittest.mock import patch, Mock
+
+from simplemonitor.Monitors import MonitorHTTP
+from simplemonitor.util import MonitorState
+
+
+class TestMonitorHTTP(unittest.TestCase):
+    def test_get_ok_default_params(self):
+        response_mock = Mock(spec=Response)
+        response_mock.status_code = 200
+
+        monitor = MonitorHTTP(
+            name="test_http_monitor",
+            config_options={
+                "url": "http://example.com",
+                "urgent": 0,
+                "tolerance": 1,
+                "remote_alert": 1,
+            }
+        )
+
+        with patch("requests.get", return_value=response_mock) as mock:
+            monitor.run_test()
+
+        result = monitor.get_result()
+        state = monitor.state()
+
+        mock.assert_called_once_with(
+            "http://example.com",
+            headers=None,
+            timeout=5,
+            verify=True,
+            allow_redirects=True,
+        )
+        self.assertEqual(state, MonitorState.OK)
+        self.assertIn('200', result)
+
+    def test_get_ok_non_default_params(self):
+        response_mock = Mock(spec=Response)
+        response_mock.status_code = 200
+
+        monitor = MonitorHTTP(
+            name="test_http_monitor",
+            config_options={
+                "url": "http://example.com",
+                "urgent": 0,
+                "tolerance": 1,
+                "remote_alert": 1,
+                "verify_hostname": False,
+                "allow_redirects": False,
+                "username": "test",
+                "password": "pass",
+                "headers": '{"test": "header"}',
+                "timeout": 10,
+            }
+        )
+
+        with patch("requests.get", return_value=response_mock) as mock:
+            monitor.run_test()
+
+        result = monitor.get_result()
+        state = monitor.state()
+
+        mock.assert_called_once_with(
+            "http://example.com",
+            headers={"test": "header"},
+            timeout=10,
+            verify=False,
+            allow_redirects=False,
+            auth=HTTPBasicAuth("test", "pass")
+        )
+        self.assertEqual(state, MonitorState.OK)
+        self.assertIn('200', result)
+        pass


### PR DESCRIPTION
Hi there! i've added ability to not follow redirects
But i've got couple of questions:
1) is it normal that i've got this on `make unit-test`
```
CRITICAL simplemonitor.logger-unnamed:file.py:222 output folder html does not exist
CRITICAL simplemonitor.logger-unnamed:file.py:424 Target folder html does not exist
============================================================== short test summary info ===============================================================
FAILED tests/test_alerter.py::TestAlerter::test_should_alert_catchup - AssertionError: <AlertType.NONE: 'none'> != <AlertType.CATCHUP: 'catchup'>
FAILED tests/test_alerter.py::TestAlerter::test_should_alert_limit - AssertionError: <AlertType.NONE: 'none'> != <AlertType.FAILURE: 'failure'>
FAILED tests/test_alerter.py::TestAlerter::test_should_alert_no_catchup - AssertionError: <AlertType.NONE: 'none'> != <AlertType.FAILURE: 'failure'>
FAILED tests/test_alerter.py::TestAlerter::test_should_alert_ooh - AssertionError: <AlertType.NONE: 'none'> != <AlertType.FAILURE: 'failure'>
FAILED tests/test_logger.py::TestHTMLLogger::test_html - AssertionError: '<!DOCTYPE html>\n<html lang="en">\n  <hea[5369 chars]l>\n' != ''
FAILED tests/test_logger.py::TestHTMLLogger::test_html_map - AssertionError: '<!DOCTYPE html>\n<html lang="en">\n  <hea[3938 chars]l>\n' != ''
FAILED tests/test_logger.py::TestHTMLLogger::test_html_tz - AssertionError: '<!DOCTYPE html>\n<html lang="en">\n  <hea[5369 chars]l>\n' != ''
```

2) I didn't understand how network test are made and for sake of perfectionism i wanna test this feature, can you help me?

Also happy new year and thanks for this small yet usefull software