### PR TITLE
Add an option to Command monitor to capture command output as info

### DIFF
--- a/docs/monitors/command.rst
+++ b/docs/monitors/command.rst
@@ -24,3 +24,10 @@ Run a command, and optionally verify its output. If the command exits non-zero, 
     :required: false
 
     if supplied, the output of the command is evaluated as an integer and if greater than this, the monitor fails. If the output cannot be converted to an integer, the monitor fails.
+
+.. confval:: show_output
+
+    :type: boolean
+    :required: false
+
+    if set to true, the output of the command will be captured as the message with a successful test.

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -8,6 +8,7 @@ import shlex
 import subprocess  # nosec
 import time
 from typing import Tuple, cast
+from markupsafe import escape
 
 from ..util import bytes_to_size_string, size_string_to_bytes
 from .monitor import Monitor, register
@@ -482,6 +483,7 @@ class MonitorCommand(Monitor):
                     "result_max settings simultaneously"
                 )
                 self.result_max = None
+        self.show_output = self.get_config_option("show_output", required_type="bool", default=False)
 
         command = self.get_config_option("command", required=True, allow_empty=False)
         self.command = shlex.split(command)
@@ -502,7 +504,10 @@ class MonitorCommand(Monitor):
                         "%s < %s" % (outasinteger, self.result_max)
                     )
                 return self.record_fail("%s >= %s" % (outasinteger, self.result_max))
-            return self.record_success()
+            msg = ""
+            if self.show_output:
+                msg = escape(_out.decode("utf-8"))
+            return self.record_success(msg)
         except Exception as exception:
             return self.record_fail(str(exception))
 
@@ -521,4 +526,4 @@ class MonitorCommand(Monitor):
         return "checking command '%s' has return status 0" % " ".join(self.command)
 
     def get_params(self) -> Tuple:
-        return (self.command, self.result_regexp_text, self.result_max)
+        return (self.command, self.result_regexp_text, self.result_max, self.show_output)

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -526,4 +526,9 @@ class MonitorCommand(Monitor):
         return "checking command '%s' has return status 0" % " ".join(self.command)
 
     def get_params(self) -> Tuple:
-        return (self.command, self.result_regexp_text, self.result_max, self.show_output)
+        return (
+            self.command,
+            self.result_regexp_text,
+            self.result_max,
+            self.show_output
+        )

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -82,11 +82,15 @@ class TestHostMonitors(unittest.TestCase):
     def test_Command_get_params(self):
         config_options = {"command": "ls /", "result_regexp": "moo", "result_max": "10"}
         m = host.MonitorCommand("test", config_options)
-        self.assertTupleEqual(m.get_params(), (["ls", "/"], "moo", None))
+        self.assertTupleEqual(m.get_params(), (["ls", "/"], "moo", None, False))
 
         config_options = {"command": "ls /", "result_max": "10"}
         m = host.MonitorCommand("test", config_options)
-        self.assertTupleEqual(m.get_params(), (["ls", "/"], "", 10))
+        self.assertTupleEqual(m.get_params(), (["ls", "/"], "", 10, False))
+
+        config_options = {"command": "ls /", "result_max": "10", "show_output": True}
+        m = host.MonitorCommand("test", config_options)
+        self.assertTupleEqual(m.get_params(), (["ls", "/"], "", 10, True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extra option for command monitor as described in #1266 
