### PR TITLE
Add count option to ping/host monitors

### DIFF
--- a/docs/monitors/host.rst
+++ b/docs/monitors/host.rst
@@ -27,3 +27,11 @@ Check a host is pingable.
     :default: automatic
 
     the regexp which matches the ping time in the output. Must set a match group named ``ms``. You may need to set this as above.
+
+.. confval:: count
+
+    :type: int
+    :required: false
+    :default: ``1``
+
+    the number of pings to send

--- a/docs/monitors/ping.rst
+++ b/docs/monitors/ping.rst
@@ -20,4 +20,10 @@ Pings a host to make sure it’s up. Uses a Python ping module instead of callin
 
     the timeout for the ping in seconds
 
-.. _pkgaudit:
+.. confval:: count
+
+    :type: int
+    :required: false
+    :default: ``1``
+
+    the number of pings to send


### PR DESCRIPTION
Adds `count` option to both the original `host` monitor and the newer `ping` monitor.

Resolves #1308 