### PR TITLE
Remove Mapbox usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,4 @@ html-bundle:
 	cd simplemonitor/html && npx webpack
 
 fix-html-tests:
-	for i in tests/html/*.html; do sed -i -E -e 's/1.12.0\+dev/__VERSION__/g' "$i"; done
+	for i in tests/html/*.html; do sed -i -E -e 's/1.12.0/__VERSION__/g' "$$i"; done

--- a/docs/loggers/html.rst
+++ b/docs/loggers/html.rst
@@ -61,10 +61,3 @@ You can use the ``upload_command`` setting to specify a command to push the gene
     :required: false
 
     three comma-separated values: the latitude the map display should start at, the longitude, and the zoom level. A good starting value for the zoom is probably between 10 and 15.
-
-.. confval:: map_token
-
-    :type: string
-    :required: yes, if using the map
-
-    an API token for mapbox.com in order to make the map work

--- a/simplemonitor/Loggers/file.py
+++ b/simplemonitor/Loggers/file.py
@@ -246,6 +246,11 @@ class HTMLLogger(Logger):
         else:
             self.map_start = None
         self.map_token = cast(str, self.get_config_option("map_token"))
+        if self.map_token:
+            self.logger_logger.info(
+                "map_token option for logger %s is no longer required; ignoring",
+                self.name,
+            )
         self._resource_files = [
             "dist/main.bundle.js*",
             "dist/maps.bundle.js*",

--- a/simplemonitor/html/status-template.html
+++ b/simplemonitor/html/status-template.html
@@ -53,12 +53,9 @@
           zoom: {{ map_start.zoom }}
         });
         L.tileLayer(
-          'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={{ map_token }}', {
+          'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 18,
-            attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
-                '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-                'Imagery &copy; <a href="https://www.mapbox.com/">Mapbox</a>',
-            id: 'mapbox/streets-v11'
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           }).addTo(mymap);
 
 {% macro map_pin(entry) -%}

--- a/tests/html/map1.html
+++ b/tests/html/map1.html
@@ -47,12 +47,9 @@
           zoom: 12
         });
         L.tileLayer(
-          'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=secret_token', {
+          'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 18,
-            attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
-                '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-                'Imagery &copy; <a href="https://www.mapbox.com/">Mapbox</a>',
-            id: 'mapbox/streets-v11'
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           }).addTo(mymap);
 
 


### PR DESCRIPTION
We can just use OSM which doesn't need a mapbox API key (and thus no registration or payment instrument).

Closes #1346
Closes #1345