### PR TITLE
show output on command monitor on failure too

### DIFF
--- a/docs/monitors/command.rst
+++ b/docs/monitors/command.rst
@@ -30,4 +30,4 @@ Run a command, and optionally verify its output. If the command exits non-zero, 
     :type: boolean
     :required: false
 
-    if set to true, the output of the command will be captured as the message with a successful test.
+    if set to true, the output of the command will be captured as the message with a successful test or appended to the message on a failed test.

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -514,7 +514,7 @@ class MonitorCommand(Monitor):
         except Exception as exception:
             msg = str(exception)
             if self.show_output:
-                msg = exception.output.decode('utf-8')
+                msg = exception.output.decode("utf-8")
             return self.record_fail(msg)
 
     def describe(self) -> str:

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -514,7 +514,7 @@ class MonitorCommand(Monitor):
         except Exception as exception:
             msg = str(exception)
             if self.show_output:
-                msg += " " + exception.output.decode('utf-8')
+                msg = exception.output.decode('utf-8')
             return self.record_fail(msg)
 
     def describe(self) -> str:

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -511,11 +511,12 @@ class MonitorCommand(Monitor):
             if self.show_output:
                 msg = escape(_out.decode("utf-8"))
             return self.record_success(msg)
-        except Exception as exception:
-            msg = str(exception)
+        except subprocess.CalledProcessError as exception:
             if self.show_output:
-                msg = exception.output.decode("utf-8")
-            return self.record_fail(msg)
+                return self.record_fail(exception.output.decode("utf-8"))
+            return self.record_fail(str(exception))
+        except Exception as exception:
+            return self.record_fail(str(exception))
 
     def describe(self) -> str:
         """Explains what this instance is checking"""

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -512,7 +512,10 @@ class MonitorCommand(Monitor):
                 msg = escape(_out.decode("utf-8"))
             return self.record_success(msg)
         except Exception as exception:
-            return self.record_fail(str(exception))
+            msg = str(exception)
+            if self.show_output:
+                msg += " " + exception.output.decode('utf-8')
+            return self.record_fail(msg)
 
     def describe(self) -> str:
         """Explains what this instance is checking"""


### PR DESCRIPTION
The  "show_output" option for the command monitor is very useful. Is there any reason not to show the output on a failure as well? I have several command line tests that generically test for errors and return output with more details about exactly what failed, which is useful to have in the alert.

