### PR TITLE
add ntfy alerter

### DIFF
--- a/simplemonitor/Alerters/__init__.py
+++ b/simplemonitor/Alerters/__init__.py
@@ -17,6 +17,7 @@ from .sns import SNSAlerter
 from .syslogger import SyslogAlerter
 from .telegram import TelegramAlerter
 from .twilio import TwilioSMSAlerter
+from .ntfy import NtfyAlerter
 
 __all__ = [
     "BulkSMSAlerter",
@@ -34,4 +35,5 @@ __all__ = [
     "SyslogAlerter",
     "TelegramAlerter",
     "TwilioSMSAlerter",
+    "NtfyAlerter"
 ]

--- a/simplemonitor/Alerters/ntfy.py
+++ b/simplemonitor/Alerters/ntfy.py
@@ -1,0 +1,76 @@
+"""
+SimpleMonitor alerts via ntfy
+"""
+
+from typing import cast
+
+import requests
+
+from ..Monitors.monitor import Monitor
+from .alerter import Alerter, AlertLength, AlertType, register
+
+
+@register
+class NtfyAlerter(Alerter):
+    """Send push notification via ntfy."""
+
+    alerter_type = "ntfy"
+
+    def __init__(self, config_options: dict) -> None:
+        super().__init__(config_options)
+        self.ntfy_token = cast(
+            str, self.get_config_option("token",default="")
+        )
+        self.ntfy_topic = cast(
+            str, self.get_config_option("topic",required=True )
+        )
+        self.ntfy_server = cast(
+            str, self.get_config_option("server", default="https://ntfy.sh")
+        )
+        self.ntfy_priority = cast(
+            str, self.get_config_option("priority", default="default")
+        )
+        self.ntfy_tags = cast(
+            int, self.get_config_option("tags", default="")
+        )
+        self.timeout = cast(
+            int, self.get_config_option("timeout", required_type="int", default=5)
+        )
+
+        self.support_catchup = True
+
+    def send_ntfy_notification(self, subject: str, body: str) -> None:
+        """Send a push notification."""
+        requests.post(
+            f"{self.ntfy_server}/{self.ntfy_topic}",
+            data=body,
+            headers={
+                    "Title": subject,
+                    "Priority": self.ntfy_priority,
+                    "Tags": self.ntfy_tags,
+                    "Authorization": f"Bearer {self.ntfy_token}"
+                },
+
+            timeout=self.timeout
+        )
+
+    def send_alert(self, name: str, monitor: Monitor) -> None:
+        """Build up the content for the push notification."""
+
+        alert_type = self.should_alert(monitor)
+
+        if alert_type == AlertType.NONE:
+            return
+        subject = self.build_message(AlertLength.NOTIFICATION, alert_type, monitor)
+        body = self.build_message(AlertLength.FULL, alert_type, monitor)
+
+        if not self._dry_run:
+            try:
+                self.send_ntfy_notification(subject, body)
+            except Exception:
+                self.alerter_logger.exception("Couldn't send ntfy notification")
+        else:
+            self.alerter_logger.info("dry_run: would send nfty notification: %s", body)
+
+    def _describe_action(self) -> str:
+        return "posting to ntfy"


### PR DESCRIPTION
Just a quick copy&paste from the pushover alerter.

Used the docs from ntfy: [https://docs.ntfy.sh/publish/](https://docs.ntfy.sh/publish/)

Web app for testing: [https://ntfy.sh/app](https://ntfy.sh/app)


i tested it against the public server. it should also work with self-hosted servers with token auth.
The default token "" seems to work in the post request. Is this ok, or should i check the token lenght? 
I don't implement the user/password auth. 

minimal config, use the public server (no auth). The topic should be a random string

```
[ntfy]
type=ntfy
topic=<random string>
```

all configs:

```
[ntfy]
type=ntfy
server=https://ntfy.xxx
token=<token>
topic=<random string>
tags=partying_face
priority=max
```
