### PR TITLE
Updated Seq logger documentation

### DIFF
--- a/docs/loggers/seq.rst
+++ b/docs/loggers/seq.rst
@@ -1,14 +1,15 @@
 seq - seq log server
 ^^^^^^^^^^^^^^^^^^^^
 
-Sends the status of monitors to a **seq** log server. See https://datalust.co for more information on Seq.
+Sends the status of monitors to a **Seq** log server. See https://datalust.co/seq for more information on Seq.
 
 .. confval:: endpoint
 
     :type: string
     :required: true
 
-    the full URI for the endpoint on the seq server, for example ``http:://localhost:5341/api/events/seq``.
+    Full URI for the endpoint on the seq server, for example ``http:://localhost:5341/api/events/raw``.
+    See the raw `API ingestion documentation <https://docs.datalust.co/docs/server-http-api#api>` for the curent endpoint URI.
 
 .. confval:: timeout
 


### PR DESCRIPTION
I updated the documentation for the Seq logger after going in rounds to understand where the ingestion is done. The original PR that introduced Seq mentions that the events are uploaded as `raw` but the endpoint given as the example was incorrect