### PR TITLE
Added ntfy icon prefix

### DIFF
--- a/docs/alerters/ntfy.rst
+++ b/docs/alerters/ntfy.rst
@@ -51,3 +51,29 @@ Send alerts using the ntfy_ service.
     :default: ``5``
 
     Timeout for HTTP request
+
+.. confval:: icon_prefix
+
+    :type: bool
+    :required: false
+    :default: ``false``
+
+    Prefix the subject line with an icon dependent on the result (failed/succeeded)
+
+.. confval:: icon_failed
+
+    :type: bool
+    :required: false
+    :default: ``274C``
+
+    Unicode code for the "failed" icon. The code is often provided as "U+<code>" (e.g. ``U+274C``). The default icon for the failed status is ❌.
+
+.. confval:: icon_succeeded
+
+    :type: bool
+    :required: false
+    :default: ``2705``
+
+    Unicode code for the "succeeded" icon. The code is often provided as "U+<code>" (e.g. ``U+2705``). The default icon for the failed status is ✅.
+
+    

--- a/docs/alerters/ntfy.rst
+++ b/docs/alerters/ntfy.rst
@@ -62,7 +62,7 @@ Send alerts using the ntfy_ service.
 
 .. confval:: icon_failed
 
-    :type: bool
+    :type: str
     :required: false
     :default: ``274C``
 
@@ -70,7 +70,7 @@ Send alerts using the ntfy_ service.
 
 .. confval:: icon_succeeded
 
-    :type: bool
+    :type: str
     :required: false
     :default: ``2705``
 

--- a/simplemonitor/Alerters/ntfy.py
+++ b/simplemonitor/Alerters/ntfy.py
@@ -67,12 +67,6 @@ class NtfyAlerter(Alerter):
 
     def send_ntfy_notification(self, subject: str, body: str) -> None:
         """Send a push notification."""
-        # prefix icon to subject when relevant
-        if self.ntfy_icon_prefix and subject.endswith("failed"):
-            subject = f"{chr(int(self.ntfy_icon_failed, 16))} {subject}"
-        if self.ntfy_icon_prefix and subject.endswith("succeeded"):
-            subject = f"{chr(int(self.ntfy_icon_succeeded, 16))} {subject}"
-        # send the notification
         requests.post(
             f"{self.ntfy_server}/{self.ntfy_topic}",
             data=body,
@@ -98,6 +92,12 @@ class NtfyAlerter(Alerter):
             return
         subject = self.build_message(AlertLength.NOTIFICATION, alert_type, monitor)
         body = self.build_message(AlertLength.FULL, alert_type, monitor)
+
+        # prefix icon to subject when relevant
+        if self.ntfy_icon_prefix and subject.endswith("failed"):
+            subject = f"{chr(int(self.ntfy_icon_failed, 16))} {subject}"
+        if self.ntfy_icon_prefix and subject.endswith("succeeded"):
+            subject = f"{chr(int(self.ntfy_icon_succeeded, 16))} {subject}"
 
         if not self._dry_run:
             try:

--- a/simplemonitor/Alerters/ntfy.py
+++ b/simplemonitor/Alerters/ntfy.py
@@ -54,16 +54,8 @@ class NtfyAlerter(Alerter):
             str,
             self.get_config_option("icon_prefix", required_type="bool", default=False),
         )
-        self.ntfy_icon_failed = cast(
-            str,
-            self.get_config_option("icon_failed", required_type="str", default="274C"),
-        )
-        self.ntfy_icon_succeeded = cast(
-            str,
-            self.get_config_option(
-                "icon_succeeded", required_type="str", default="2705"
-            ),
-        )
+        self.ntfy_icon_failed = chr(int(cast(str,self.get_config_option("icon_failed", required_type="str", default="274C")), 16))
+        self.ntfy_icon_succeeded = chr(int(cast(str, self.get_config_option("icon_succeeded", required_type="str", default="2705")), 16)) 
 
     def send_ntfy_notification(self, subject: str, body: str) -> None:
         """Send a push notification."""
@@ -95,9 +87,9 @@ class NtfyAlerter(Alerter):
 
         # prefix icon to subject when relevant
         if self.ntfy_icon_prefix and subject.endswith("failed"):
-            subject = f"{chr(int(self.ntfy_icon_failed, 16))} {subject}"
+            subject = f"{self.ntfy_icon_failed} {subject}"
         if self.ntfy_icon_prefix and subject.endswith("succeeded"):
-            subject = f"{chr(int(self.ntfy_icon_succeeded, 16))} {subject}"
+            subject = f"{self.ntfy_icon_succeeded} {subject}"
 
         if not self._dry_run:
             try:


### PR DESCRIPTION
The `ntfy` messages do not immediately discriminate between failed and successful events. This PR adds the possibility to prefix the messages with an icon depending on the status.

- Added the ability to use an icon as the prefix for the subject 
- Updated documentation