### PR TITLE
New logger to dump a JSON file with all attributes of a Monitor & ISO dates

### DIFF
--- a/docs/loggers/json_full.rst
+++ b/docs/loggers/json_full.rst
@@ -1,0 +1,12 @@
+json_full - write a full JSON status file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Writes the status of monitors to a JSON file.
+This file includes all serializable data from a monitor instance and all dates are in plain ISO format.
+
+.. confval:: filename
+
+    :type: string
+    :required: true
+
+    the filename to write to


### PR DESCRIPTION
This PR is for a logger that creates a JSON file with all the attributes of a Monitor. It also uses ISO 8601 for dates to make parsing easier (reference: https://xkcd.com/1179/).

In addition to the fact that the world needs another JSON file, I intend to use it in a dashboard that will allow for selective display of data.

**IMPORTANT NOTE**: this Logger requires [`jsonpickle`](https://jsonpickle.github.io/index.html) but I do not know how to hint this in the code (I need to learn Poetry). If you do not intend to pull in extra dependencies please reject this PR as it won't work without.