### PR TITLE
update tls-expiry to support TLS 1.3

### DIFF
--- a/docs/monitors/tls_expiry.rst
+++ b/docs/monitors/tls_expiry.rst
@@ -5,8 +5,6 @@ Checks an SSL/TLS certificate is not due to expire/has expired.
 
 .. note:: This monitor's :ref:`gap<gap>` defaults to 12 hours.
 
-.. warning:: Due to a limitation of the underlying Python modules in use, this does not currently support TLS 1.3.
-
 .. confval:: host
 
     :type: string

--- a/simplemonitor/Monitors/network.py
+++ b/simplemonitor/Monitors/network.py
@@ -446,8 +446,7 @@ class MonitorTLSCert(Monitor):
         self.sni = cast(Optional[str], self.get_config_option("sni", required=False))
 
     def run_test(self) -> bool:
-        # Note: at time of writing, ssl does not support TLS1.3
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_context.verify_mode = ssl.CERT_REQUIRED
         ssl_context.check_hostname = bool(self.sni)
         ssl_context.load_default_certs()


### PR DESCRIPTION
PROTOCOL_TLSv1_2 is deprecated since Python 3.6.
Instead we can switch to https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT
As simplemonitor already required Python 3.6, this one does not break compatibility.

Tested against an nginx 1.26.1 with OpenSSL 3.2.1 using Pyton 3.12.4.
nginx was TLS 1.3 only.

Tested with various internet facing web servers that also support TLS 1.1 and 1.2.