### PR TITLE
Make config test exit with error code if broken

### DIFF
--- a/simplemonitor/const.py
+++ b/simplemonitor/const.py
@@ -1,0 +1,5 @@
+"""
+Constants for simplemonitor
+"""
+
+EXIT_CODE_CONFIG_FAILED = 3

--- a/simplemonitor/html/status-template.html
+++ b/simplemonitor/html/status-template.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <link rel="shortcut icon" href="data:,">
 
     <title>{{status}}@{{host}} monitor</title>
 

--- a/simplemonitor/monitor.py
+++ b/simplemonitor/monitor.py
@@ -7,6 +7,7 @@ import logging
 import os
 import sys
 
+from .const import EXIT_CODE_CONFIG_FAILED
 from .simplemonitor import SimpleMonitor
 from .version import VERSION
 
@@ -225,7 +226,7 @@ def main() -> None:
             sys.exit(0)
         else:
             main_logger.error("Config test failed")
-            sys.exit(2)
+            sys.exit(EXIT_CODE_CONFIG_FAILED)
 
     if options.one_shot:
         main_logger.warning(

--- a/simplemonitor/monitor.py
+++ b/simplemonitor/monitor.py
@@ -220,13 +220,13 @@ def main() -> None:
         max_workers=options.threads,
     )
 
-    if options.test:
-        if m.config_ok:
+    if m.config_ok:
+        if options.test:
             main_logger.warning("Config test complete. Exiting.")
             sys.exit(0)
-        else:
-            main_logger.error("Config test failed")
-            sys.exit(EXIT_CODE_CONFIG_FAILED)
+    else:
+        main_logger.error("Configuration not valid")
+        sys.exit(EXIT_CODE_CONFIG_FAILED)
 
     if options.one_shot:
         main_logger.warning(

--- a/simplemonitor/monitor.py
+++ b/simplemonitor/monitor.py
@@ -220,8 +220,12 @@ def main() -> None:
     )
 
     if options.test:
-        main_logger.warning("Config test complete. Exiting.")
-        sys.exit(0)
+        if m.config_ok:
+            main_logger.warning("Config test complete. Exiting.")
+            sys.exit(0)
+        else:
+            main_logger.error("Config test failed")
+            sys.exit(2)
 
     if options.one_shot:
         main_logger.warning(

--- a/simplemonitor/simplemonitor.py
+++ b/simplemonitor/simplemonitor.py
@@ -671,12 +671,12 @@ class SimpleMonitor:
                     continue
                 logger.save_result2(key, monitor)
 
-            try:
-                # need to work on a copy here to prevent the dicts changing under us
-                # during the loop, as remote instances can connect and update our data
-                # unpredictably
-                for host_monitors in self.remote_monitors.copy().values():
-                    for name, monitor in host_monitors.copy().items():
+            # need to work on a copy here to prevent the dicts changing under us
+            # during the loop, as remote instances can connect and update our data
+            # unpredictably
+            for host_monitors in self.remote_monitors.copy().values():
+                for name, monitor in host_monitors.copy().items():
+                    try:
                         if check_group_match(monitor.group, logger.groups):
                             logger.save_result2(name, monitor)
                         else:
@@ -687,8 +687,11 @@ class SimpleMonitor:
                                 monitor.group,
                                 logger.groups,
                             )
-            except Exception:  # pragma: no cover
-                module_logger.exception("exception while logging remote monitors")
+                    except Exception:  # pragma: no cover
+                        module_logger.exception(
+                            "exception while logging remote monitors (offending monitor: %s)",
+                            name,
+                        )
 
     def do_alert(self, alerter: Alerter) -> None:
         """Use the given alerter object to send an alert, if needed."""

--- a/tests/html/map1.html
+++ b/tests/html/map1.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <link rel="shortcut icon" href="data:,">
 
     <title>FAIL@fake_hostname.local monitor</title>
 

--- a/tests/html/test1.html
+++ b/tests/html/test1.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <link rel="shortcut icon" href="data:,">
 
     <title>FAIL@fake_hostname.local monitor</title>
 

--- a/tests/html/test2.html
+++ b/tests/html/test2.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <link rel="shortcut icon" href="data:,">
 
     <title>FAIL@fake_hostname.local monitor</title>
 

--- a/tests/html/test3.html
+++ b/tests/html/test3.html
@@ -6,6 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <link rel="shortcut icon" href="data:,">
 
     <title>FAIL@fake_hostname.local monitor</title>
 

--- a/tests/monitors.ini
+++ b/tests/monitors.ini
@@ -254,9 +254,6 @@ max=0.01
 type=null
 runon=some-unlikely-hostname
 
-[nc]
-type=nc
-
 [compound1-fail]
 type=compound
 monitors=ping-fail,pkg-fail


### PR DESCRIPTION
Per discussion with @cpina, make `-t` exit non-zero (I picked `2`) if something isn't right with the config. Mostly this covers using a monitor/alerter/logger type which isn't known; other config errors currently will just throw an exception and exit 1 still.

If not testing the config, then the previous behaviour is currently retained: SimpleMonitor will try to continue with the config it did load. Not sure if that's the best choice yet; it probably should exit if the config is broken either way.