### PR TITLE
test(alerter): fix time and timezone issues in alerter tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ per-file-ignores =
     simplemonitor/__init__.py:F401
 
 [isort]
-known_third_party = arrow,boto3,botocore,freezegun,importlib_metadata,jinja2,markupsafe,oauthlib,paho,paramiko,psutil,pyaarlo,pytest,requests,ring_doorbell,sphinx,sphinx_rtd_theme,twilio,win32event,win32service,win32serviceutil
+known_third_party = arrow,boto3,botocore,freezegun,importlib_metadata,jinja2,markupsafe,oauthlib,paho,paramiko,psutil,pyaarlo,requests,ring_doorbell,sphinx,sphinx_rtd_theme,twilio,win32event,win32service,win32serviceutil
 known_first_party = Alerters,Loggers,Monitors,envconfig,util,simplemonitor
 line_length=88
 multi_line_output=3


### PR DESCRIPTION
Fixes #1330

Some tests wouldn't pass locally if `TZ` was unset, or not set to to, e.g., UTC.
    
One issue was the fallback to `"local"` if `TZ` was unset - this is a valid value internally within simplemonitor, but I don't think valid as a time zone.
    
Also, having many tests use the local timezone creates some unpredictability in cases where there are hardcoded offsets, or where the test depends on the local timezone having a specific offset from UTC.
    
Mock `TZ` as `UTC` or `MST` explicitly, and adjust existing tests based on offsets from that where needed.
    
Fix / unskip some skipped tests

A few comments:
* ~I didn't fix all the skipped tests, but hopefully this might help identify fixes for them?~ They're all unskipped now.
* These pass for me locally now, but I'm not 100% sure that all the logic is correct, so please review carefully
* Should confirm that these work in your environment, and that there's no remaining logic that would create tests that are flaky depending on the time of day or other factors.