### PR TITLE
test(monitor): mock file write for recovery tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ docs/vendor
 monitor.log
 monitor.pid
 output.json
-did_recover*
 simplemonitor.egg-info
 dist
 /html


### PR DESCRIPTION
Fixes #1356
The tests for `did_recovery` and `did_recovered` touch a file that they leave around.
While we could use a temporary file, in this context, it seems like mocking subprocess.Popen should be sufficient.