### PR TITLE
Support for `failure_doc` in slack alerter

### DIFF
--- a/simplemonitor/Alerters/slack.py
+++ b/simplemonitor/Alerters/slack.py
@@ -69,6 +69,14 @@ class SlackAlerter(Alerter):
                 {"title": "Description", "value": monitor.describe()},
             ]
 
+            if monitor.failure_doc:
+                fields.append(
+                    {
+                        "title": "Documentation",
+                        "value": monitor.failure_doc,
+                    }
+                )
+
             try:
                 if monitor.recover_info != "":
                     fields.append(


### PR DESCRIPTION
Adds a field called `Documentation` in the Slack alerter's FAILURE alert with the value from the monitor's `failure_doc`, if failure_doc is configured.