### PR TITLE
Fix repeated notifications when delayed/catch-up notifications enabled

### DIFF
--- a/simplemonitor/Alerters/alerter.py
+++ b/simplemonitor/Alerters/alerter.py
@@ -283,20 +283,18 @@ class Alerter:
         if virtual_failure_count:
             self.alerter_logger.debug("monitor %s has failed", monitor.name)
             # Monitor has failed (not just first time)
-            if self._delay_notification:
-                # Delayed (catch-up) notifications are enabled
-                if not out_of_hours:
-                    # Not out of hours
-                    try:
-                        self._ooh_failures.remove(monitor.name)
-                        # if it was in there and we support catchup alerts, do it
-                        if self.support_catchup:
-                            self.alerter_logger.debug(
-                                "alert for monitor %s is CATCHUP", monitor.name
-                            )
-                            return AlertType.CATCHUP
-                    except ValueError:
-                        pass
+            if self._delay_notification and not out_of_hours:
+                # Delayed (catch-up) notifications are enabled, and it's time to send the delayed notification
+                if monitor.name in self._ooh_failures:
+                    # The monitor had failed during ooh
+                    self._ooh_failures.remove(monitor.name)
+                    # if we support catchup alerts, do it
+                    if self.support_catchup:
+                        self.alerter_logger.debug(
+                            "alert for monitor %s is CATCHUP", monitor.name
+                        )
+                        return AlertType.CATCHUP
+                    # send failure if catchup wasn't supported
                     self.alerter_logger.debug(
                         "alert for monitor %s is FAILURE", monitor.name
                     )


### PR DESCRIPTION
This should hopefully fix the issue where in-hours notifications repeat unexpectedly when `delay` (catch-up) notifications are enabled

( Previous logic always returned FAILURE|CATCHUP notification when delay was true, even if the monitor wasn't actually in the ooh_failures list )

Fixes: #1348 #987
