### PR TITLE
Ensure tooltip title attribute value is escaped

### DIFF
--- a/simplemonitor/html/status-template.html
+++ b/simplemonitor/html/status-template.html
@@ -95,7 +95,7 @@
             <span
               data-toggle="tooltip"
               data-placement="right"
-              title="{{entry.description}}"
+              title="{{entry.description|e}}"
               >{{entry.monitor_name}}</span
             >
           </td>


### PR DESCRIPTION
It seems that the tooltip title value wasn't escaped. When a value contained `<` or `>` the template output didn't display correctly. This PR ensures `entry.description` is always escaped when used as the value for tooltip title.