### PR TITLE
fix(alerters): use regular text email instead of MIME

### DIFF
--- a/simplemonitor/Alerters/alerter.py
+++ b/simplemonitor/Alerters/alerter.py
@@ -434,7 +434,7 @@ class Alerter:
             raise NotImplementedError
         elif length == AlertLength.FULL:
             if alert_type in [AlertType.CATCHUP, AlertType.FAILURE]:
-                message = """
+                message = """\
                 Monitor {monitor.name}{host} {alert_verb}!
                 Failed at: {failure_time} (down {downtime})
                 Virtual failure count: {vfc}
@@ -450,7 +450,7 @@ class Alerter:
                         monitor.failure_doc
                     )
             elif alert_type == AlertType.SUCCESS:
-                message = """
+                message = """\
                 Monitor {monitor.name}{host} {alert_verb}!
                 Recovered at: {recovered_time} (was down for {downtime})
                 Additional info: {result}

--- a/simplemonitor/Alerters/mail.py
+++ b/simplemonitor/Alerters/mail.py
@@ -4,8 +4,7 @@ SimpleMonitor alerts via email/SMTP
 
 import email.utils
 import smtplib
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+from email.message import EmailMessage
 from typing import Optional, cast
 
 from ..Monitors.monitor import Monitor
@@ -49,7 +48,7 @@ class EMailAlerter(Alerter):
         if alert_type == AlertType.NONE:
             return
 
-        message = MIMEMultipart()
+        message = EmailMessage()
         message["From"] = self.from_addr
         message["To"] = self.to_addr.replace(";", ",")
         message["Date"] = email.utils.formatdate()
@@ -62,7 +61,7 @@ class EMailAlerter(Alerter):
             AlertLength.NOTIFICATION, alert_type, monitor
         )
         body = self.build_message(AlertLength.FULL, alert_type, monitor)
-        message.attach(MIMEText(body, "plain"))
+        message.set_content(body)
 
         if not self._dry_run:
             try:

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -539,7 +539,7 @@ class TestMessageBuilding(unittest.TestCase):
                 alerter.AlertLength.FULL, alerter.AlertType.FAILURE, m
             ),
             textwrap.dedent(
-                """
+                """\
                 Monitor test on {hostname} failed!
                 Failed at: {expected_time} (down 0+00:00:00)
                 Virtual failure count: 1
@@ -561,7 +561,7 @@ class TestMessageBuilding(unittest.TestCase):
                 alerter.AlertLength.FULL, alerter.AlertType.FAILURE, m
             ),
             textwrap.dedent(
-                """
+                """\
                 Monitor test on {host} failed!
                 Failed at: {expected_time} (down 0+00:00:00)
                 Virtual failure count: 1
@@ -585,7 +585,7 @@ class TestMessageBuilding(unittest.TestCase):
                 alerter.AlertLength.FULL, alerter.AlertType.SUCCESS, m
             ),
             textwrap.dedent(
-                """
+                """\
                 Monitor winning on {host} succeeded!
                 Recovered at: {expected_time} (was down for 0+00:00:00)
                 Additional info: 


### PR DESCRIPTION
- Remove some extra newlines at the beginning of email alerts
- Use regular plaintext email vs. MIME so that we receive the plain text email inline instead of as a single text/plain attachment.

While MIME has some advantages if we were sending attachments, using multipart/mixed messages to send both HTML and plaintext versions, it doesn't appear to me that we're doing that

before (notice extra line and attachment)
<img width="708" alt="image" src="https://github.com/user-attachments/assets/b8588086-682f-4dde-ba91-08f826888d99" />

after:
<img width="705" alt="image" src="https://github.com/user-attachments/assets/411e53b3-d98b-440a-afc8-1c41ac8542b6" />