### PR TITLE
Use America/Phoenix timezone instead of MST timezone

### DIFF
--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -14,7 +14,7 @@ from simplemonitor.Monitors import monitor
 # Create a consistent "local" timezone and offset for the tests, for tests that
 # compare the offset between UTC and local time. For simplicity and
 # predictability, use a time zone that doesn't have daylight savings.
-TZ_LOCAL = "MST"
+TZ_LOCAL = "America/Phoenix"
 TZ_LOCAL_OFFSET = -7
 TZ_UTC = "UTC"
 
@@ -208,8 +208,8 @@ class TestAlerter(unittest.TestCase):
         a = alerter.Alerter(
             {
                 "times_type": "only",
-                "time_lower": "09:00",  # 9:00 MST, 16:00 UTC
-                "time_upper": "10:00",  # 10:00 MST, 17:00 UTC
+                "time_lower": "09:00",  # 9:00 America/Phoenix, 16:00 UTC
+                "time_upper": "10:00",  # 10:00 America/Phoenix, 17:00 UTC
             }
         )
         with freeze_time("15:00"):
@@ -241,8 +241,8 @@ class TestAlerter(unittest.TestCase):
         a = alerter.Alerter(
             {
                 "times_type": "not",
-                "time_lower": "09:00",  # 9:00 MST, 16:00 UTC
-                "time_upper": "10:00",  # 10:00 MST, 17:00 UTC
+                "time_lower": "09:00",  # 9:00 America/Phoenix, 16:00 UTC
+                "time_upper": "10:00",  # 10:00 America/Phoenix, 17:00 UTC
             }
         )
         with freeze_time("15:55"):


### PR DESCRIPTION
In Debian trixie MST timezone is not available in the "tzdata" package and it needs "tzdata-legacy". America/Phoenix is the same timezone available in "tzdata".