### PR TITLE
chore: resolve pyproject.toml errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,36 +4,39 @@ version = "1.14.0"
 description = "A simple network and host monitor"
 license = "BSD-3-Clause"
 authors = [
-    {name = "James Seward", email = "james@jamesoff.net"},
+  {name = "James Seward", email = "james@jamesoff.net"},
 ]
 requires-python = ">=3.10"
 readme = "README.md"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Environment :: No Input/Output (Daemon)",
+  "Intended Audience :: System Administrators",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Topic :: System :: Monitoring",
+  "Typing :: Typed",
+]
+dynamic = ["dependencies"]
+
+[project.scripts]
+simplemonitor = "simplemonitor.monitor:main"
+winmonitor = "simplemonitor.winmonitor:main"
+
+[project.urls]
 homepage = "https://github.com/jamesoff/simplemonitor"
 repository = "https://github.com/jamesoff/simplemonitor"
 documentation = "http://jamesoff.github.io/simplemonitor/"
-classifiers = [
-	"Development Status :: 5 - Production/Stable",
-	"Environment :: Console",
-	"Environment :: No Input/Output (Daemon)",
-	"Intended Audience :: System Administrators",
-	"License :: OSI Approved :: BSD License",
-	"Operating System :: OS Independent",
-	"Programming Language :: Python :: 3 :: Only",
-	"Programming Language :: Python :: 3",
-	"Topic :: System :: Monitoring",
-	"Typing :: Typed",
-]
-include = [
-	"simplemonitor/html/dist/*",
-	"simplemonitor/html/status-template.html",
-]
 
 [tool.poetry]
 requires-poetry = ">=2.0"
-
-[tool.poetry.scripts]
-simplemonitor = "simplemonitor.monitor:main"
-winmonitor = "simplemonitor.winmonitor:main"
+include = [
+    "simplemonitor/html/dist/*",
+    "simplemonitor/html/status-template.html",
+]
 
 [tool.poetry.dependencies]
 python = "^3.10.0"


### PR DESCRIPTION
Resolve warnings found by validate-pyproject and poetry check (hopefully this resolves the continuing issues with dependabot not being able to figure out how to update dependencies?)

- Move project URLs to `project.urls` section
- Set dynamic dependencies
- Move `include` to `tool.poetry` section

Also remove hard tabs (use 2 character spaces, preferred for toml)

It might also be possible to move the dependencies directly to the project dependencies (see notes below)?

Errors without this change:
```
% poetry run validate-pyproject ./pyproject.toml
Invalid file: ./pyproject.toml
[ERROR] `project` must not contain {'repository', 'homepage', 'include', 'documentation'} properties
% poetry check                                  
Warning: Defining console scripts in [tool.poetry.scripts] is deprecated. Use [project.scripts] instead. ([tool.poetry.scripts] should only be used for scripts of type 'file').
Warning: [tool.poetry.dependencies] is set but [project.dependencies] is not and 'dependencies' is not in [project.dynamic]. You should either migrate [tool.poetry.depencencies] to [project.dependencies] (if you do not need Poetry-specific features) or add [project.dependencies] in addition to [tool.poetry.dependencies] or add 'dependencies' to [project.dynamic].
```

Some references:
https://github.com/pypa/packaging-problems/issues/606
https://python-poetry.org/docs/pyproject/#packages
https://github.com/astral-sh/rye/issues/1078
https://stackoverflow.com/questions/77933206/pyproject-toml-dynamic-version-dependency


It might also be possible to get dynamic version working, but I didn't try that here. `poetry build` does seem to still function with these changes:
```
% poetry build
Building simplemonitor (1.14.0)
Building sdist
  - Building sdist
  - Built simplemonitor-1.14.0.tar.gz
Building wheel
  - Building wheel
  - Built simplemonitor-1.14.0-py3-none-any.whl
```