### PR TITLE
Teach pkgaudit how to ignorelist

### DIFF
--- a/docs/monitors/pkgaudit.rst
+++ b/docs/monitors/pkgaudit.rst
@@ -10,3 +10,12 @@ Fails if ``pkg audit`` reports any vulnerable packages installed.
     :default: :file:`/usr/local/sbin/pkg`
 
     the path to the ``pkg`` binary
+
+.. confval:: ignore
+
+    :type: comma-separated list of string
+    :required: false
+
+    a list of VuXML identifiers to ignore. These should be the
+    GUID-style identifiers (they appear in the URL), for
+    example ``613d0f9e-d477-11f0-9e85-03ddfea11990``.

--- a/simplemonitor/Monitors/host.py
+++ b/simplemonitor/Monitors/host.py
@@ -4,11 +4,13 @@ Monitor things on a host for SimpleMonitor
 
 import json
 import os
+import os.path
 import re
 import shlex
 import subprocess  # nosec
 import time
 from typing import Optional, Tuple, cast
+from urllib.parse import urlsplit
 
 from markupsafe import escape
 from packaging.version import parse
@@ -339,15 +341,20 @@ class MonitorPortAudit(Monitor):
 
 @register
 class MonitorPkgAudit(Monitor):
-    """Check a host doesn't have outstanding security issues."""
+    """Check a host doesn't have outstanding security issues.
+
+    Allows overriding of entries by vuxml UUID
+    """
 
     monitor_type = "pkgaudit"
-    regexp = re.compile(r"(\d+) problem\(s\) in \w+ installed package(s|\(s\)) found")
     path = ""
 
     def __init__(self, name: str, config_options: dict) -> None:
         super().__init__(name, config_options)
         self.path = self.get_config_option("path", default="")
+        self.ignore_list = cast(
+            list[str], self.get_config_option("ignore", required_type="list[str]")
+        )
 
     def describe(self) -> str:
         return "Checking for insecure packages."
@@ -374,11 +381,26 @@ class MonitorPkgAudit(Monitor):
             count = int(output["pkg_count"])
         except KeyError:
             return self.record_fail("Failed to find pkg_count in output")
+        ignored = 0
+        if self.ignore_list:
+            for package in output.get("packages", {}).values():
+                for issue in package.get("issues", []):
+                    if url := issue.get("url"):
+                        url_info = urlsplit(url)
+                        filename = os.path.splitext(os.path.basename(url_info.path))[0]
+                        if filename in self.ignore_list:
+                            count -= 1
+                            ignored += 1
+                            break
+        if ignored:
+            ignore_text = f"({ignored} problem{'s' if ignored > 1 else ''} ignored)"
+        else:
+            ignore_text = ""
         if count == 0:
-            return self.record_success()
-        if count == 1:
-            return self.record_fail("1 problem found")
-        return self.record_fail("%d problems found" % count)
+            return self.record_success(ignore_text)
+        return self.record_fail(
+            f"{count} problem{'s' if count > 1 else ''} found {ignore_text}".strip()
+        )
 
 
 @register

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -1,5 +1,8 @@
 # type: ignore
+import json
+import subprocess
 import unittest
+from unittest.mock import patch
 
 from simplemonitor.Monitors import host
 
@@ -90,6 +93,60 @@ class TestHostMonitors(unittest.TestCase):
         config_options = {"command": "ls /", "result_max": "10", "show_output": True}
         m = host.MonitorCommand("test", config_options)
         self.assertTupleEqual(m.get_params(), (["ls", "/"], "", 10, True))
+
+    @patch("subprocess.run")
+    def test_pkgaudit_ignore(self, subprocess_run_fn):
+        config_options = {"ignore": "abc-123"}
+        mock_response = {
+            "pkg_count": 1,
+            "packages": {
+                "python311": {
+                    "issues": [{"url": "https//vuxml.freebsd.org/freebsd/abc-123.html"}]
+                }
+            },
+        }
+        subprocess_run_fn.return_value = subprocess.CompletedProcess(
+            ["pkg", "audit"], returncode=1, stdout=json.dumps(mock_response).encode()
+        )
+        m = host.MonitorPkgAudit("test", config_options)
+        m.run_test()
+        self.assertEqual(m.last_result, "(1 problem ignored)")
+
+    @patch("subprocess.run")
+    def test_pkgaudit_ignore_fail(self, subprocess_run_fn):
+        config_options = {"ignore": "abc-123"}
+        mock_response = {
+            "pkg_count": 1,
+            "packages": {
+                "python311": {
+                    "issues": [{"url": "https//vuxml.freebsd.org/freebsd/abc-456.html"}]
+                }
+            },
+        }
+        subprocess_run_fn.return_value = subprocess.CompletedProcess(
+            ["pkg", "audit"], returncode=1, stdout=json.dumps(mock_response).encode()
+        )
+        m = host.MonitorPkgAudit("test", config_options)
+        m.run_test()
+        self.assertEqual(m.last_result, "1 problem found")
+
+    @patch("subprocess.run")
+    def test_pkgaudit_noignore_fail(self, subprocess_run_fn):
+        config_options = {}
+        mock_response = {
+            "pkg_count": 1,
+            "packages": {
+                "python311": {
+                    "issues": [{"url": "https//vuxml.freebsd.org/freebsd/abc-456.html"}]
+                }
+            },
+        }
+        subprocess_run_fn.return_value = subprocess.CompletedProcess(
+            ["pkg", "audit"], returncode=1, stdout=json.dumps(mock_response).encode()
+        )
+        m = host.MonitorPkgAudit("test", config_options)
+        m.run_test()
+        self.assertEqual(m.last_result, "1 problem found")
 
 
 if __name__ == "__main__":

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -148,6 +148,20 @@ class TestHostMonitors(unittest.TestCase):
         m.run_test()
         self.assertEqual(m.last_result, "1 problem found")
 
+    @patch("subprocess.run")
+    def test_pkgaudit_ignore_empty(self, subprocess_run_fn):
+        config_options = {}
+        mock_response = {
+            "pkg_count": 0,
+            "packages": {},
+        }
+        subprocess_run_fn.return_value = subprocess.CompletedProcess(
+            ["pkg", "audit"], returncode=1, stdout=json.dumps(mock_response).encode()
+        )
+        m = host.MonitorPkgAudit("test", config_options)
+        m.run_test()
+        self.assertEqual(m.last_result, "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add an `ignore` config option to ignore VuXML ids for things which aren't going to be fixed any time soon